### PR TITLE
Building construction component

### DIFF
--- a/spec/TheGame/Application/Component/BuildingConstruction/Command/CancelConstructingCommandSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Command/CancelConstructingCommandSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\BuildingConstruction\Command;
+
+use PhpSpec\ObjectBehavior;
+
+final class CancelConstructingCommandSpec extends ObjectBehavior
+{
+    public function it_has_planet_id(): void
+    {
+
+    }
+
+    public function it_has_building_type(): void
+    {
+
+    }
+}

--- a/spec/TheGame/Application/Component/BuildingConstruction/Command/CancelConstructingCommandSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Command/CancelConstructingCommandSpec.php
@@ -5,16 +5,28 @@ declare(strict_types=1);
 namespace spec\TheGame\Application\Component\BuildingConstruction\Command;
 
 use PhpSpec\ObjectBehavior;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
 
 final class CancelConstructingCommandSpec extends ObjectBehavior
 {
+    public function let(): void
+    {
+        $planetId = "05FEB5A6-285B-46A8-8A3D-10280C68ECBA";
+        $buildingType = BuildingType::ResourceStorage->value;
+
+        $this->beConstructedWith(
+            $planetId,
+            $buildingType,
+        );
+    }
+
     public function it_has_planet_id(): void
     {
-
+        $this->getPlanetId()->shouldReturn("05FEB5A6-285B-46A8-8A3D-10280C68ECBA");
     }
 
     public function it_has_building_type(): void
     {
-
+        $this->getBuildingType()->shouldReturn(BuildingType::ResourceStorage->value);
     }
 }

--- a/spec/TheGame/Application/Component/BuildingConstruction/Command/FinishConstructingCommandSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Command/FinishConstructingCommandSpec.php
@@ -5,16 +5,28 @@ declare(strict_types=1);
 namespace spec\TheGame\Application\Component\BuildingConstruction\Command;
 
 use PhpSpec\ObjectBehavior;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
 
 final class FinishConstructingCommandSpec extends ObjectBehavior
 {
+    public function let(): void
+    {
+        $planetId = "05FEB5A6-285B-46A8-8A3D-10280C68ECBA";
+        $buildingType = BuildingType::ResourceStorage->value;
+
+        $this->beConstructedWith(
+            $planetId,
+            $buildingType,
+        );
+    }
+
     public function it_has_planet_id(): void
     {
-
+        $this->getPlanetId()->shouldReturn("05FEB5A6-285B-46A8-8A3D-10280C68ECBA");
     }
 
     public function it_has_building_type(): void
     {
-
+        $this->getBuildingType()->shouldReturn(BuildingType::ResourceStorage->value);
     }
 }

--- a/spec/TheGame/Application/Component/BuildingConstruction/Command/FinishConstructingCommandSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Command/FinishConstructingCommandSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\BuildingConstruction\Command;
+
+use PhpSpec\ObjectBehavior;
+
+final class FinishConstructingCommandSpec extends ObjectBehavior
+{
+    public function it_has_planet_id(): void
+    {
+
+    }
+
+    public function it_has_building_type(): void
+    {
+
+    }
+}

--- a/spec/TheGame/Application/Component/BuildingConstruction/Command/StartConstructingCommandSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Command/StartConstructingCommandSpec.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\BuildingConstruction\Command;
+
+use PhpSpec\ObjectBehavior;
+
+final class StartConstructingCommandSpec extends ObjectBehavior
+{
+    public function it_has_planet_id(): void
+    {
+
+    }
+
+    public function it_has_building_type(): void
+    {
+
+    }
+
+    public function it_has_resource_context_id(): void
+    {
+
+    }
+
+    public function it_has_no_resource_context_id(): void
+    {
+
+    }
+}

--- a/spec/TheGame/Application/Component/BuildingConstruction/Command/StartConstructingCommandSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Command/StartConstructingCommandSpec.php
@@ -5,26 +5,49 @@ declare(strict_types=1);
 namespace spec\TheGame\Application\Component\BuildingConstruction\Command;
 
 use PhpSpec\ObjectBehavior;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
 
 final class StartConstructingCommandSpec extends ObjectBehavior
 {
+    public function let(): void
+    {
+        $planetId = "05FEB5A6-285B-46A8-8A3D-10280C68ECBA";
+        $buildingType = BuildingType::ResourceStorage->value;
+        $resourceContextId = "68A3E097-C576-4087-9655-1ECAB8AA92F6";
+
+        $this->beConstructedWith(
+            $planetId,
+            $buildingType,
+            $resourceContextId,
+        );
+    }
+
     public function it_has_planet_id(): void
     {
-
+        $this->getPlanetId()->shouldReturn("05FEB5A6-285B-46A8-8A3D-10280C68ECBA");
     }
 
     public function it_has_building_type(): void
     {
-
+        $this->getBuildingType()->shouldReturn(BuildingType::ResourceStorage->value);
     }
 
     public function it_has_resource_context_id(): void
     {
-
+        $this->getResourceContextId()->shouldReturn("68A3E097-C576-4087-9655-1ECAB8AA92F6");
     }
 
     public function it_has_no_resource_context_id(): void
     {
+        $planetId = "05FEB5A6-285B-46A8-8A3D-10280C68ECBA";
+        $buildingType = BuildingType::ResourceStorage->value;
 
+        $this->beConstructedWith(
+            $planetId,
+            $buildingType,
+            null,
+        );
+
+        $this->getResourceContextId()->shouldReturn(null);
     }
 }

--- a/spec/TheGame/Application/Component/BuildingConstruction/CommandHandler/CancelConstructingCommandHandlerSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/CommandHandler/CancelConstructingCommandHandlerSpec.php
@@ -5,16 +5,75 @@ declare(strict_types=1);
 namespace spec\TheGame\Application\Component\BuildingConstruction\CommandHandler;
 
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use TheGame\Application\Component\Balance\Bridge\BuildingContextInterface;
+use TheGame\Application\Component\BuildingConstruction\BuildingRepositoryInterface;
+use TheGame\Application\Component\BuildingConstruction\Command\CancelConstructingCommand;
+use TheGame\Application\Component\BuildingConstruction\Domain\Entity\Building;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\BuildingConstructionHasBeenCancelledEvent;
+use TheGame\Application\Component\BuildingConstruction\Domain\Exception\BuildingHasNotBeenBuiltYetFoundException;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
+use TheGame\Application\SharedKernel\Domain\PlanetId;
+use TheGame\Application\SharedKernel\Domain\ResourceRequirementsInterface;
+use TheGame\Application\SharedKernel\EventBusInterface;
 
 final class CancelConstructingCommandHandlerSpec extends ObjectBehavior
 {
-    public function it_throws_exception_when_cant_find_aggregate(): void
-    {
-
+    public function let(
+        BuildingRepositoryInterface $buildingRepository,
+        BuildingContextInterface $buildingBalanceContext,
+        EventBusInterface $eventBus,
+    ): void {
+        $this->beConstructedWith(
+            $buildingRepository,
+            $buildingBalanceContext,
+            $eventBus,
+        );
     }
 
-    public function it_cancels_constructing(): void
-    {
+    public function it_throws_exception_when_cant_find_aggregate(
+        BuildingRepositoryInterface $buildingRepository,
+    ): void {
+        $planetId = "1D632422-951F-4181-A48D-5AD654260B2B";
+        $buildingRepository->findForPlanet(new PlanetId($planetId), BuildingType::ResourceMine)
+            ->willReturn(null);
 
+        $command = new CancelConstructingCommand(
+            $planetId,
+            BuildingType::ResourceMine->value,
+        );
+        $this->shouldThrow(BuildingHasNotBeenBuiltYetFoundException::class)
+            ->during('__invoke', [$command]);
+    }
+
+    public function it_cancels_constructing(
+        BuildingRepositoryInterface $buildingRepository,
+        BuildingContextInterface $buildingBalanceContext,
+        EventBusInterface $eventBus,
+        Building $building,
+        ResourceRequirementsInterface $resourceRequirements,
+    ): void {
+        $planetId = "1D632422-951F-4181-A48D-5AD654260B2B";
+        $buildingRepository->findForPlanet(new PlanetId($planetId), BuildingType::ResourceMine)
+            ->willReturn($building);
+
+        $buildingBalanceContext->getResourceRequirements(5, BuildingType::ResourceMine)
+            ->willReturn($resourceRequirements);
+
+        $building->cancelUpgrading()->shouldBeCalledOnce();
+        $building->getCurrentLevel()->willReturn(5);
+        $resourceRequirements->toScalarArray()
+            ->willReturn([
+                "26E29382-BA42-4675-B643-93E9006B089B" => 500,
+            ]);
+
+        $eventBus->dispatch(Argument::type(BuildingConstructionHasBeenCancelledEvent::class))
+            ->shouldBeCalledOnce();
+
+        $command = new CancelConstructingCommand(
+            $planetId,
+            BuildingType::ResourceMine->value,
+        );
+        $this->__invoke($command);
     }
 }

--- a/spec/TheGame/Application/Component/BuildingConstruction/CommandHandler/CancelConstructingCommandHandlerSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/CommandHandler/CancelConstructingCommandHandlerSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\BuildingConstruction\CommandHandler;
+
+use PhpSpec\ObjectBehavior;
+
+final class CancelConstructingCommandHandlerSpec extends ObjectBehavior
+{
+    public function it_throws_exception_when_cant_find_aggregate(): void
+    {
+
+    }
+
+    public function it_cancels_constructing(): void
+    {
+
+    }
+}

--- a/spec/TheGame/Application/Component/BuildingConstruction/CommandHandler/FinishConstructingCommandHandlerSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/CommandHandler/FinishConstructingCommandHandlerSpec.php
@@ -4,17 +4,78 @@ declare(strict_types=1);
 
 namespace spec\TheGame\Application\Component\BuildingConstruction\CommandHandler;
 
+use PhpParser\Node\Arg;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use TheGame\Application\Component\BuildingConstruction\BuildingRepositoryInterface;
+use TheGame\Application\Component\BuildingConstruction\Command\FinishConstructingCommand;
+use TheGame\Application\Component\BuildingConstruction\Domain\Entity\Building;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\Factory\BuildingTypeEventFactoryInterface;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\ResourceStorageConstructionHasBeenFinishedEvent;
+use TheGame\Application\Component\BuildingConstruction\Domain\Exception\BuildingHasNotBeenBuiltYetFoundException;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
+use TheGame\Application\SharedKernel\Domain\PlanetId;
+use TheGame\Application\SharedKernel\EventBusInterface;
 
 final class FinishConstructingCommandHandlerSpec extends ObjectBehavior
 {
-    public function it_throws_exception_when_aggregate_is_not_found(): void
-    {
-
+    public function let(
+        BuildingRepositoryInterface $buildingRepository,
+        EventBusInterface $eventBus,
+        BuildingTypeEventFactoryInterface $buildingTypeEventFactory,
+    ): void {
+        $this->beConstructedWith(
+            $buildingRepository,
+            $eventBus,
+            $buildingTypeEventFactory,
+        );
     }
 
-    public function it_finishes_constructing(): void
-    {
+    public function it_throws_exception_when_aggregate_is_not_found(
+        BuildingRepositoryInterface $buildingRepository,
+    ): void {
+        $planetId = "1D632422-951F-4181-A48D-5AD654260B2B";
 
+        $buildingRepository->findForPlanet(new PlanetId($planetId), BuildingType::ResourceStorage)
+            ->willReturn(null);
+
+        $command = new FinishConstructingCommand(
+            $planetId,
+            BuildingType::ResourceStorage->value,
+        );
+        $this->shouldThrow(BuildingHasNotBeenBuiltYetFoundException::class)
+            ->during('__invoke', [$command]);
+    }
+
+    public function it_finishes_constructing(
+        BuildingRepositoryInterface $buildingRepository,
+        EventBusInterface $eventBus,
+        BuildingTypeEventFactoryInterface $buildingTypeEventFactory,
+        Building $building,
+    ): void {
+        $planetId = "1D632422-951F-4181-A48D-5AD654260B2B";
+
+        $buildingRepository->findForPlanet(new PlanetId($planetId), BuildingType::ResourceStorage)
+            ->willReturn($building);
+
+        $building->finishUpgrading()->shouldBeCalledOnce();
+
+        $resourceId = "73140C59-DE9C-4959-8E18-1271EB32D76A";
+        $event = new ResourceStorageConstructionHasBeenFinishedEvent(
+            $planetId,
+            $resourceId,
+            1
+        );
+        $buildingTypeEventFactory->createConstructingFinishedEvent($building)
+            ->willReturn($event);
+
+        $eventBus->dispatch(Argument::type(ResourceStorageConstructionHasBeenFinishedEvent::class))
+            ->shouldBeCalledOnce();
+
+        $command = new FinishConstructingCommand(
+            $planetId,
+            BuildingType::ResourceStorage->value,
+        );
+        $this->__invoke($command);
     }
 }

--- a/spec/TheGame/Application/Component/BuildingConstruction/CommandHandler/FinishConstructingCommandHandlerSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/CommandHandler/FinishConstructingCommandHandlerSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\BuildingConstruction\CommandHandler;
+
+use PhpSpec\ObjectBehavior;
+
+final class FinishConstructingCommandHandlerSpec extends ObjectBehavior
+{
+    public function it_throws_exception_when_aggregate_is_not_found(): void
+    {
+
+    }
+
+    public function it_finishes_constructing(): void
+    {
+
+    }
+}

--- a/spec/TheGame/Application/Component/BuildingConstruction/CommandHandler/FinishConstructingCommandHandlerSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/CommandHandler/FinishConstructingCommandHandlerSpec.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace spec\TheGame\Application\Component\BuildingConstruction\CommandHandler;
 
-use PhpParser\Node\Arg;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use TheGame\Application\Component\BuildingConstruction\BuildingRepositoryInterface;

--- a/spec/TheGame/Application/Component/BuildingConstruction/CommandHandler/StartConstructingCommandHandlerSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/CommandHandler/StartConstructingCommandHandlerSpec.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace spec\TheGame\Application\Component\BuildingConstruction\CommandHandler;
 
-use DateTimeImmutable;
 use DateTimeInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -56,7 +55,9 @@ final class StartConstructingCommandHandlerSpec extends ObjectBehavior
             ->willReturn(null);
 
         $buildingFactory->createNew(
-            new PlanetId($planetId), BuildingType::ResourceStorage, new ResourceId($resourceContextId),
+            new PlanetId($planetId),
+            BuildingType::ResourceStorage,
+            new ResourceId($resourceContextId),
         )->willReturn($building);
 
         $building->getCurrentLevel()->willReturn(1);
@@ -102,7 +103,9 @@ final class StartConstructingCommandHandlerSpec extends ObjectBehavior
             ->willReturn(null);
 
         $buildingFactory->createNew(
-            new PlanetId($planetId), BuildingType::ResourceStorage, new ResourceId($resourceContextId),
+            new PlanetId($planetId),
+            BuildingType::ResourceStorage,
+            new ResourceId($resourceContextId),
         )->willReturn($building);
 
         $building->getCurrentLevel()->willReturn(1);

--- a/spec/TheGame/Application/Component/BuildingConstruction/CommandHandler/StartConstructingCommandHandlerSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/CommandHandler/StartConstructingCommandHandlerSpec.php
@@ -4,22 +4,164 @@ declare(strict_types=1);
 
 namespace spec\TheGame\Application\Component\BuildingConstruction\CommandHandler;
 
+use DateTimeImmutable;
+use DateTimeInterface;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use TheGame\Application\Component\Balance\Bridge\BuildingContextInterface;
+use TheGame\Application\Component\BuildingConstruction\BuildingRepositoryInterface;
+use TheGame\Application\Component\BuildingConstruction\Command\StartConstructingCommand;
+use TheGame\Application\Component\BuildingConstruction\Domain\Entity\Building;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\BuildingConstructionHasBeenStartedEvent;
+use TheGame\Application\Component\BuildingConstruction\Domain\Exception\InsufficientResourcesException;
+use TheGame\Application\Component\BuildingConstruction\Domain\Factory\BuildingFactoryInterface;
+use TheGame\Application\Component\ResourceStorage\Bridge\ResourceAvailabilityCheckerInterface;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
+use TheGame\Application\SharedKernel\Domain\PlanetId;
+use TheGame\Application\SharedKernel\Domain\ResourceId;
+use TheGame\Application\SharedKernel\Domain\ResourceRequirementsInterface;
+use TheGame\Application\SharedKernel\EventBusInterface;
 
 final class StartConstructingCommandHandlerSpec extends ObjectBehavior
 {
-    public function it_throws_exception_when_aggregate_is_not_found(): void
-    {
-
+    public function let(
+        ResourceAvailabilityCheckerInterface $resourceAvailabilityChecker,
+        BuildingRepositoryInterface $buildingRepository,
+        BuildingContextInterface $buildingBalanceContext,
+        BuildingFactoryInterface $buildingFactory,
+        EventBusInterface $eventBus,
+    ): void {
+        $this->beConstructedWith(
+            $resourceAvailabilityChecker,
+            $buildingRepository,
+            $buildingBalanceContext,
+            $buildingFactory,
+            $eventBus,
+        );
     }
 
-    public function it_throws_exception_when_storage_hasnt_enough_resources(): void
-    {
+    public function it_creates_building_when_the_aggregate_is_not_found(
+        BuildingRepositoryInterface $buildingRepository,
+        BuildingFactoryInterface $buildingFactory,
+        Building $building,
+        BuildingContextInterface $buildingBalanceContext,
+        ResourceAvailabilityCheckerInterface $resourceAvailabilityChecker,
+        ResourceRequirementsInterface $resourceRequirements,
+        EventBusInterface $eventBus,
+    ): void {
+        $planetId = "E7AF94C7-488C-46E4-8C44-DCD8F62B2A45";
+        $resourceContextId = "52B4E60C-5CCE-4483-968E-D23D9240A18A";
 
+        $buildingRepository->findForPlanet(new PlanetId($planetId), BuildingType::ResourceStorage)
+            ->willReturn(null);
+
+        $buildingFactory->createNew(
+            new PlanetId($planetId), BuildingType::ResourceStorage, new ResourceId($resourceContextId),
+        )->willReturn($building);
+
+        $building->getCurrentLevel()->willReturn(1);
+        $building->getType()->willReturn(BuildingType::ResourceStorage);
+
+        $buildingBalanceContext->getResourceRequirements(1, BuildingType::ResourceStorage)
+            ->willReturn($resourceRequirements);
+
+        $resourceAvailabilityChecker->check(new PlanetId($planetId), $resourceRequirements)
+            ->willReturn(true);
+
+        $buildingBalanceContext->getBuildingDuration(1, BuildingType::ResourceStorage)
+            ->willReturn(500);
+        $building->startUpgrading(Argument::type(DateTimeInterface::class))->shouldBeCalledOnce();
+
+        $resourceRequirements->toScalarArray()->willReturn([
+            "0E0987D9-6D13-45A0-9CB5-3000DA9E2174" => 420,
+        ]);
+
+        $eventBus->dispatch(Argument::type(BuildingConstructionHasBeenStartedEvent::class))
+            ->shouldBeCalledOnce();
+
+        $command = new StartConstructingCommand(
+            $planetId,
+            BuildingType::ResourceStorage->value,
+            $resourceContextId,
+        );
+        $this->__invoke($command);
     }
 
-    public function it_starts_constructing_the_building(): void
-    {
+    public function it_throws_exception_when_storage_hasnt_enough_resources(
+        BuildingRepositoryInterface $buildingRepository,
+        BuildingFactoryInterface $buildingFactory,
+        Building $building,
+        BuildingContextInterface $buildingBalanceContext,
+        ResourceAvailabilityCheckerInterface $resourceAvailabilityChecker,
+        ResourceRequirementsInterface $resourceRequirements,
+    ): void {
+        $planetId = "E7AF94C7-488C-46E4-8C44-DCD8F62B2A45";
+        $resourceContextId = "52B4E60C-5CCE-4483-968E-D23D9240A18A";
 
+        $buildingRepository->findForPlanet(new PlanetId($planetId), BuildingType::ResourceStorage)
+            ->willReturn(null);
+
+        $buildingFactory->createNew(
+            new PlanetId($planetId), BuildingType::ResourceStorage, new ResourceId($resourceContextId),
+        )->willReturn($building);
+
+        $building->getCurrentLevel()->willReturn(1);
+        $building->getType()->willReturn(BuildingType::ResourceStorage);
+
+        $buildingBalanceContext->getResourceRequirements(1, BuildingType::ResourceStorage)
+            ->willReturn($resourceRequirements);
+
+        $resourceAvailabilityChecker->check(new PlanetId($planetId), $resourceRequirements)
+            ->willReturn(false);
+
+        $command = new StartConstructingCommand(
+            $planetId,
+            BuildingType::ResourceStorage->value,
+            $resourceContextId,
+        );
+        $this->shouldThrow(InsufficientResourcesException::class)
+            ->during('__invoke', [$command]);
+    }
+
+    public function it_starts_constructing_the_building(
+        BuildingRepositoryInterface $buildingRepository,
+        Building $building,
+        BuildingContextInterface $buildingBalanceContext,
+        ResourceAvailabilityCheckerInterface $resourceAvailabilityChecker,
+        ResourceRequirementsInterface $resourceRequirements,
+        EventBusInterface $eventBus,
+    ): void {
+        $planetId = "E7AF94C7-488C-46E4-8C44-DCD8F62B2A45";
+        $resourceContextId = "52B4E60C-5CCE-4483-968E-D23D9240A18A";
+
+        $buildingRepository->findForPlanet(new PlanetId($planetId), BuildingType::ResourceStorage)
+            ->willReturn($building);
+
+        $building->getCurrentLevel()->willReturn(1);
+        $building->getType()->willReturn(BuildingType::ResourceStorage);
+
+        $buildingBalanceContext->getResourceRequirements(1, BuildingType::ResourceStorage)
+            ->willReturn($resourceRequirements);
+
+        $resourceAvailabilityChecker->check(new PlanetId($planetId), $resourceRequirements)
+            ->willReturn(true);
+
+        $buildingBalanceContext->getBuildingDuration(1, BuildingType::ResourceStorage)
+            ->willReturn(500);
+        $building->startUpgrading(Argument::type(DateTimeInterface::class))->shouldBeCalledOnce();
+
+        $resourceRequirements->toScalarArray()->willReturn([
+            "0E0987D9-6D13-45A0-9CB5-3000DA9E2174" => 420,
+        ]);
+
+        $eventBus->dispatch(Argument::type(BuildingConstructionHasBeenStartedEvent::class))
+            ->shouldBeCalledOnce();
+
+        $command = new StartConstructingCommand(
+            $planetId,
+            BuildingType::ResourceStorage->value,
+            $resourceContextId,
+        );
+        $this->__invoke($command);
     }
 }

--- a/spec/TheGame/Application/Component/BuildingConstruction/CommandHandler/StartConstructingCommandHandlerSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/CommandHandler/StartConstructingCommandHandlerSpec.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\BuildingConstruction\CommandHandler;
+
+use PhpSpec\ObjectBehavior;
+
+final class StartConstructingCommandHandlerSpec extends ObjectBehavior
+{
+    public function it_throws_exception_when_aggregate_is_not_found(): void
+    {
+
+    }
+
+    public function it_throws_exception_when_storage_hasnt_enough_resources(): void
+    {
+
+    }
+
+    public function it_starts_constructing_the_building(): void
+    {
+
+    }
+}

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Entity/BuildingSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Entity/BuildingSpec.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\BuildingConstruction\Domain\Entity;
+
+use PhpSpec\ObjectBehavior;
+
+final class BuildingSpec extends ObjectBehavior
+{
+    public function it_has_identifier(): void
+    {
+
+    }
+
+    public function it_has_planet_identifier(): void
+    {
+
+    }
+
+    public function it_has_current_level(): void
+    {
+
+    }
+
+    public function it_has_a_type(): void
+    {
+
+    }
+
+    public function it_starts_upgrading(): void
+    {
+
+    }
+
+    public function it_throws_exception_when_starts_upgrading_building_which_is_already_during_upgrade(): void
+    {
+
+    }
+
+    public function it_cancels_upgrading(): void
+    {
+
+    }
+
+    public function it_throws_exception_when_cancels_upgrading_a_building_which_is_not_during_upgrade(): void
+    {
+
+    }
+
+    public function it_finishes_upgrading_building(): void
+    {
+
+    }
+
+    public function it_throws_exception_when_finishes_upgrading_a_building_which_is_not_during_upgrade(): void
+    {
+
+    }
+
+    public function it_throws_exception_when_finishes_upgrading_a_building_when_upgrade_time_didnt_pass(): void
+    {
+
+    }
+
+    public function it_has_resource_context_id(): void
+    {
+
+    }
+
+    public function it_has_no_resource_context_id(): void
+    {
+
+    }
+}

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Entity/BuildingSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Entity/BuildingSpec.php
@@ -4,72 +4,128 @@ declare(strict_types=1);
 
 namespace spec\TheGame\Application\Component\BuildingConstruction\Domain\Entity;
 
+use DateTimeImmutable;
 use PhpSpec\ObjectBehavior;
+use TheGame\Application\Component\BuildingConstruction\Domain\BuildingId;
+use TheGame\Application\Component\BuildingConstruction\Domain\Exception\BuildingIsAlreadyUpgradingException;
+use TheGame\Application\Component\BuildingConstruction\Domain\Exception\BuildingIsNotUpgradingYetException;
+use TheGame\Application\Component\BuildingConstruction\Domain\Exception\BuildingTimeHasNotPassedException;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
+use TheGame\Application\SharedKernel\Domain\PlanetId;
+use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
+use TheGame\Application\SharedKernel\Domain\ResourceId;
+use TheGame\Application\SharedKernel\Domain\ResourceIdInterface;
 
 final class BuildingSpec extends ObjectBehavior
 {
+    public function let(): void
+    {
+        $planetId = "0CAB5B81-969A-4C2A-88B6-91B7B4B45E68";
+        $buildingId = "B51FAABD-AC4C-4806-A3E7-A35234E54ABB";
+        $buildingType = BuildingType::ResourceStorage;
+        $resourceContextId = "D4EF6F12-604D-4590-944F-0BD5F5270A53";
+
+        $this->beConstructedWith(
+            new PlanetId($planetId),
+            new BuildingId($buildingId),
+            $buildingType,
+            new ResourceId($resourceContextId),
+        );
+    }
+
     public function it_has_identifier(): void
     {
-
+        $this->getId()->shouldHaveType(BuildingId::class);
+        $this->getId()->getUuid()->shouldReturn("B51FAABD-AC4C-4806-A3E7-A35234E54ABB");
     }
 
     public function it_has_planet_identifier(): void
     {
-
+        $this->getPlanetId()->shouldHaveType(PlanetIdInterface::class);
+        $this->getPlanetId()->getUuid()->shouldReturn("0CAB5B81-969A-4C2A-88B6-91B7B4B45E68");
     }
 
     public function it_has_current_level(): void
     {
-
+        $this->getCurrentLevel()->shouldReturn(0);
     }
 
     public function it_has_a_type(): void
     {
-
+        $this->getType()->shouldReturn(BuildingType::ResourceStorage);
     }
 
     public function it_starts_upgrading(): void
     {
-
+        $this->startUpgrading(new DateTimeImmutable("now +10 seconds"));
     }
 
     public function it_throws_exception_when_starts_upgrading_building_which_is_already_during_upgrade(): void
     {
+        $this->startUpgrading(new DateTimeImmutable("now +10 seconds"));
 
+        $this->shouldThrow(BuildingIsAlreadyUpgradingException::class)
+            ->during('startUpgrading', [new DateTimeImmutable("now +10 seconds")]);
     }
 
     public function it_cancels_upgrading(): void
     {
+        $this->startUpgrading(new DateTimeImmutable("now +10 seconds"));
 
+        $this->cancelUpgrading();
     }
 
     public function it_throws_exception_when_cancels_upgrading_a_building_which_is_not_during_upgrade(): void
     {
+        $this->startUpgrading(new DateTimeImmutable("now +10 seconds"));
 
+        $this->cancelUpgrading();
+        $this->shouldThrow(BuildingIsNotUpgradingYetException::class)
+            ->during('cancelUpgrading', []);
     }
 
     public function it_finishes_upgrading_building(): void
     {
-
+        $this->startUpgrading(new DateTimeImmutable("now -10 seconds"));
+        $this->finishUpgrading();
     }
 
     public function it_throws_exception_when_finishes_upgrading_a_building_which_is_not_during_upgrade(): void
     {
+        $this->startUpgrading(new DateTimeImmutable("now -10 seconds"));
+        $this->finishUpgrading();
 
+        $this->shouldThrow(BuildingIsNotUpgradingYetException::class)
+            ->during('finishUpgrading', []);
     }
 
     public function it_throws_exception_when_finishes_upgrading_a_building_when_upgrade_time_didnt_pass(): void
     {
+        $this->startUpgrading(new DateTimeImmutable("now +1 second"));
 
+        $this->shouldThrow(BuildingTimeHasNotPassedException::class)
+            ->during('finishUpgrading', []);
     }
 
     public function it_has_resource_context_id(): void
     {
-
+        $this->getResourceContextId()->shouldHaveType(ResourceIdInterface::class);
+        $this->getResourceContextId()->getUuid()->shouldReturn("D4EF6F12-604D-4590-944F-0BD5F5270A53");
     }
 
     public function it_has_no_resource_context_id(): void
     {
+        $planetId = "0CAB5B81-969A-4C2A-88B6-91B7B4B45E68";
+        $buildingId = "B51FAABD-AC4C-4806-A3E7-A35234E54ABB";
+        $buildingType = BuildingType::ResourceStorage;
 
+        $this->beConstructedWith(
+            new PlanetId($planetId),
+            new BuildingId($buildingId),
+            $buildingType,
+            null,
+        );
+
+        $this->getResourceContextId()->shouldReturn(null);
     }
 }

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenCancelledEventSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenCancelledEventSpec.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\BuildingConstruction\Domain\Event;
+
+use PhpSpec\ObjectBehavior;
+
+final class BuildingConstructionHasBeenCancelledEventSpec extends ObjectBehavior
+{
+    public function it_has_planet_id(): void
+    {
+
+    }
+
+    public function it_has_building_type(): void
+    {
+
+    }
+
+    public function it_has_resource_requirements(): void
+    {
+
+    }
+
+    public function it_throws_exception_when_resource_requirements_is_an_array_with_no_string_keys(): void
+    {
+
+    }
+
+    public function it_throws_exception_when_resource_requirements_is_an_array_with_no_integer_value(): void
+    {
+
+    }
+}

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenCancelledEventSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenCancelledEventSpec.php
@@ -4,32 +4,74 @@ declare(strict_types=1);
 
 namespace spec\TheGame\Application\Component\BuildingConstruction\Domain\Event;
 
+use InvalidArgumentException;
 use PhpSpec\ObjectBehavior;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
 
 final class BuildingConstructionHasBeenCancelledEventSpec extends ObjectBehavior
 {
+    public function let(): void
+    {
+        $planetId = "6B685A5A-E279-4E8D-A9D4-0EEC6E7F0F3D";
+        $resourceRequirements = [
+            "6842FCCF-9905-41FF-B542-4788579F0847" => 750,
+        ];
+
+        $this->beConstructedWith(
+            $planetId, BuildingType::ResourceStorage->value, $resourceRequirements,
+        );
+    }
+
     public function it_has_planet_id(): void
     {
-
+        $this->getPlanetId()->shouldReturn("6B685A5A-E279-4E8D-A9D4-0EEC6E7F0F3D");
     }
 
     public function it_has_building_type(): void
     {
-
+        $this->getBuildingType()->shouldReturn(BuildingType::ResourceStorage->value);
     }
 
     public function it_has_resource_requirements(): void
     {
-
+        $this->getResourceRequirements()->shouldReturn([
+            "6842FCCF-9905-41FF-B542-4788579F0847" => 750,
+        ]);
     }
 
     public function it_throws_exception_when_resource_requirements_is_an_array_with_no_string_keys(): void
     {
+        $planetId = "6B685A5A-E279-4E8D-A9D4-0EEC6E7F0F3D";
+        $buildingType = BuildingType::ResourceStorage->value;
+        $resourceRequirements = [
+            300 => 750,
+        ];
 
+        $this->beConstructedWith(
+            $planetId, $buildingType, $resourceRequirements,
+        );
+
+        $this->shouldThrow(InvalidArgumentException::class)
+            ->during('__construct', [
+                $planetId, $buildingType, $resourceRequirements,
+            ]);
     }
 
     public function it_throws_exception_when_resource_requirements_is_an_array_with_no_integer_value(): void
     {
+        $planetId = "6B685A5A-E279-4E8D-A9D4-0EEC6E7F0F3D";
+        $buildingType = BuildingType::ResourceStorage->value;
+        $resourceRequirements = [
+            "6842FCCF-9905-41FF-B542-4788579F0847" => "not-int-value",
+        ];
 
+        $this->beConstructedWith(
+            $planetId, $buildingType, $resourceRequirements,
+        );
+
+        $this->shouldThrow(InvalidArgumentException::class)
+            ->during('__construct', [
+                $planetId, $buildingType, $resourceRequirements,
+            ]);
     }
 }

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenCancelledEventSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenCancelledEventSpec.php
@@ -18,7 +18,9 @@ final class BuildingConstructionHasBeenCancelledEventSpec extends ObjectBehavior
         ];
 
         $this->beConstructedWith(
-            $planetId, BuildingType::ResourceStorage->value, $resourceRequirements,
+            $planetId,
+            BuildingType::ResourceStorage->value,
+            $resourceRequirements,
         );
     }
 
@@ -48,7 +50,9 @@ final class BuildingConstructionHasBeenCancelledEventSpec extends ObjectBehavior
         ];
 
         $this->beConstructedWith(
-            $planetId, $buildingType, $resourceRequirements,
+            $planetId,
+            $buildingType,
+            $resourceRequirements,
         );
 
         $this->shouldThrow(InvalidArgumentException::class)
@@ -66,7 +70,9 @@ final class BuildingConstructionHasBeenCancelledEventSpec extends ObjectBehavior
         ];
 
         $this->beConstructedWith(
-            $planetId, $buildingType, $resourceRequirements,
+            $planetId,
+            $buildingType,
+            $resourceRequirements,
         );
 
         $this->shouldThrow(InvalidArgumentException::class)

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenFinishedEventSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenFinishedEventSpec.php
@@ -15,7 +15,9 @@ final class BuildingConstructionHasBeenFinishedEventSpec extends ObjectBehavior
         $level = 1;
 
         $this->beConstructedWith(
-            $planetId, BuildingType::ResourceStorage->value, $level,
+            $planetId,
+            BuildingType::ResourceStorage->value,
+            $level,
         );
     }
 

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenFinishedEventSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenFinishedEventSpec.php
@@ -5,21 +5,32 @@ declare(strict_types=1);
 namespace spec\TheGame\Application\Component\BuildingConstruction\Domain\Event;
 
 use PhpSpec\ObjectBehavior;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
 
 final class BuildingConstructionHasBeenFinishedEventSpec extends ObjectBehavior
 {
+    public function let(): void
+    {
+        $planetId = "6B685A5A-E279-4E8D-A9D4-0EEC6E7F0F3D";
+        $level = 1;
+
+        $this->beConstructedWith(
+            $planetId, BuildingType::ResourceStorage->value, $level,
+        );
+    }
+
     public function it_has_planet_id(): void
     {
-
+        $this->getPlanetId()->shouldReturn("6B685A5A-E279-4E8D-A9D4-0EEC6E7F0F3D");
     }
 
     public function it_has_building_type(): void
     {
-
+        $this->getBuildingType()->shouldReturn(BuildingType::ResourceStorage->value);
     }
 
     public function it_has_level(): void
     {
-
+        $this->getLevel()->shouldReturn(1);
     }
 }

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenFinishedEventSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenFinishedEventSpec.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\BuildingConstruction\Domain\Event;
+
+use PhpSpec\ObjectBehavior;
+
+final class BuildingConstructionHasBeenFinishedEventSpec extends ObjectBehavior
+{
+    public function it_has_planet_id(): void
+    {
+
+    }
+
+    public function it_has_building_type(): void
+    {
+
+    }
+
+    public function it_has_level(): void
+    {
+
+    }
+}

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenStartedEventSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenStartedEventSpec.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\BuildingConstruction\Domain\Event;
+
+use PhpSpec\ObjectBehavior;
+
+final class BuildingConstructionHasBeenStartedEventSpec extends ObjectBehavior
+{
+    public function it_has_planet_id(): void
+    {
+
+    }
+
+    public function it_has_building_type(): void
+    {
+
+    }
+
+    public function it_has_resource_requirements(): void
+    {
+
+    }
+
+    public function it_throws_exception_when_resource_requirements_is_an_array_with_no_string_keys(): void
+    {
+
+    }
+
+    public function it_throws_exception_when_resource_requirements_is_an_array_with_no_integer_value(): void
+    {
+
+    }
+}

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenStartedEventSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenStartedEventSpec.php
@@ -4,32 +4,74 @@ declare(strict_types=1);
 
 namespace spec\TheGame\Application\Component\BuildingConstruction\Domain\Event;
 
+use InvalidArgumentException;
 use PhpSpec\ObjectBehavior;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
 
 final class BuildingConstructionHasBeenStartedEventSpec extends ObjectBehavior
 {
+    public function let(): void
+    {
+        $planetId = "6B685A5A-E279-4E8D-A9D4-0EEC6E7F0F3D";
+        $resourceRequirements = [
+            "6842FCCF-9905-41FF-B542-4788579F0847" => 750,
+        ];
+
+        $this->beConstructedWith(
+            $planetId, BuildingType::ResourceStorage->value, $resourceRequirements,
+        );
+    }
+
     public function it_has_planet_id(): void
     {
-
+        $this->getPlanetId()->shouldReturn("6B685A5A-E279-4E8D-A9D4-0EEC6E7F0F3D");
     }
 
     public function it_has_building_type(): void
     {
-
+        $this->getBuildingType()->shouldReturn(BuildingType::ResourceStorage->value);
     }
 
     public function it_has_resource_requirements(): void
     {
-
+        $this->getResourceRequirements()->shouldReturn([
+            "6842FCCF-9905-41FF-B542-4788579F0847" => 750,
+        ]);
     }
 
     public function it_throws_exception_when_resource_requirements_is_an_array_with_no_string_keys(): void
     {
+        $planetId = "6B685A5A-E279-4E8D-A9D4-0EEC6E7F0F3D";
+        $buildingType = BuildingType::ResourceStorage->value;
+        $resourceRequirements = [
+            300 => 750,
+        ];
 
+        $this->beConstructedWith(
+            $planetId, $buildingType, $resourceRequirements,
+        );
+
+        $this->shouldThrow(InvalidArgumentException::class)
+            ->during('__construct', [
+                $planetId, $buildingType, $resourceRequirements,
+            ]);
     }
 
     public function it_throws_exception_when_resource_requirements_is_an_array_with_no_integer_value(): void
     {
+        $planetId = "6B685A5A-E279-4E8D-A9D4-0EEC6E7F0F3D";
+        $buildingType = BuildingType::ResourceStorage->value;
+        $resourceRequirements = [
+            "6842FCCF-9905-41FF-B542-4788579F0847" => "not-int-value",
+        ];
 
+        $this->beConstructedWith(
+            $planetId, $buildingType, $resourceRequirements,
+        );
+
+        $this->shouldThrow(InvalidArgumentException::class)
+            ->during('__construct', [
+                $planetId, $buildingType, $resourceRequirements,
+            ]);
     }
 }

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenStartedEventSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenStartedEventSpec.php
@@ -18,7 +18,9 @@ final class BuildingConstructionHasBeenStartedEventSpec extends ObjectBehavior
         ];
 
         $this->beConstructedWith(
-            $planetId, BuildingType::ResourceStorage->value, $resourceRequirements,
+            $planetId,
+            BuildingType::ResourceStorage->value,
+            $resourceRequirements,
         );
     }
 
@@ -48,7 +50,9 @@ final class BuildingConstructionHasBeenStartedEventSpec extends ObjectBehavior
         ];
 
         $this->beConstructedWith(
-            $planetId, $buildingType, $resourceRequirements,
+            $planetId,
+            $buildingType,
+            $resourceRequirements,
         );
 
         $this->shouldThrow(InvalidArgumentException::class)
@@ -66,7 +70,9 @@ final class BuildingConstructionHasBeenStartedEventSpec extends ObjectBehavior
         ];
 
         $this->beConstructedWith(
-            $planetId, $buildingType, $resourceRequirements,
+            $planetId,
+            $buildingType,
+            $resourceRequirements,
         );
 
         $this->shouldThrow(InvalidArgumentException::class)

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/Factory/BuildingTypeEventFactorySpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/Factory/BuildingTypeEventFactorySpec.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\BuildingConstruction\Domain\Event\Factory;
+
+use PhpSpec\ObjectBehavior;
+
+final class BuildingTypeEventFactorySpec extends ObjectBehavior
+{
+    public function it_creates_a_construction_finished_event_for_mine_building(): void
+    {
+
+    }
+
+    public function it_creates_a_construction_finished_event_for_storage_building(): void
+    {
+
+    }
+
+    public function it_creates_a_generic_construction_finished_event(): void
+    {
+
+    }
+}

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/Factory/BuildingTypeEventFactorySpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/Factory/BuildingTypeEventFactorySpec.php
@@ -4,22 +4,51 @@ declare(strict_types=1);
 
 namespace spec\TheGame\Application\Component\BuildingConstruction\Domain\Event\Factory;
 
+use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\ObjectBehavior;
+use TheGame\Application\Component\BuildingConstruction\Domain\Entity\Building;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\ResourceMineConstructionHasBeenFinishedEvent;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\ResourceStorageConstructionHasBeenFinishedEvent;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
+use TheGame\Application\SharedKernel\Domain\PlanetId;
+use TheGame\Application\SharedKernel\Domain\ResourceId;
 
 final class BuildingTypeEventFactorySpec extends ObjectBehavior
 {
-    public function it_creates_a_construction_finished_event_for_mine_building(): void
-    {
+    public function it_creates_a_construction_finished_event_for_mine_building(
+        Building $building
+    ): void {
+        $planetId = "A16D8FB1-FD3B-4C25-A1FC-D04857EF917A";
+        $building->getPlanetId()->willReturn(new PlanetId($planetId));
 
+        $resourceContextId = "3FA9C84B-F2A7-44D0-8EA3-63DD66D23899";
+        $building->getResourceContextId()->willReturn(new ResourceId($resourceContextId));
+
+        $building->getCurrentLevel()->willReturn(1);
+        $building->getType()->willReturn(BuildingType::ResourceMine);
+
+        $this->createConstructingFinishedEvent($building)
+            ->shouldReturnAnInstanceOf(ResourceMineConstructionHasBeenFinishedEvent::class);
     }
 
-    public function it_creates_a_construction_finished_event_for_storage_building(): void
-    {
+    public function it_creates_a_construction_finished_event_for_storage_building(
+        Building $building
+    ): void {
+        $planetId = "A16D8FB1-FD3B-4C25-A1FC-D04857EF917A";
+        $building->getPlanetId()->willReturn(new PlanetId($planetId));
 
+        $resourceContextId = "3FA9C84B-F2A7-44D0-8EA3-63DD66D23899";
+        $building->getResourceContextId()->willReturn(new ResourceId($resourceContextId));
+
+        $building->getCurrentLevel()->willReturn(1);
+        $building->getType()->willReturn(BuildingType::ResourceStorage);
+
+        $this->createConstructingFinishedEvent($building)
+            ->shouldReturnAnInstanceOf(ResourceStorageConstructionHasBeenFinishedEvent::class);
     }
 
     public function it_creates_a_generic_construction_finished_event(): void
     {
-
+        throw new SkippingException('Cannot spec this scenario, because of using enum');
     }
 }

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/ResourceMineConstructionHasBeenFinishedEventSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/ResourceMineConstructionHasBeenFinishedEventSpec.php
@@ -27,9 +27,4 @@ final class ResourceMineConstructionHasBeenFinishedEventSpec extends ObjectBehav
     {
 
     }
-
-    public function it_has_no_resource_context_id(): void
-    {
-
-    }
 }

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/ResourceMineConstructionHasBeenFinishedEventSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/ResourceMineConstructionHasBeenFinishedEventSpec.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\BuildingConstruction\Domain\Event;
+
+use PhpSpec\ObjectBehavior;
+
+final class ResourceMineConstructionHasBeenFinishedEventSpec extends ObjectBehavior
+{
+    public function it_has_planet_id(): void
+    {
+
+    }
+
+    public function it_has_building_type(): void
+    {
+
+    }
+
+    public function it_has_current_level(): void
+    {
+
+    }
+
+    public function it_has_resource_context_id(): void
+    {
+
+    }
+
+    public function it_has_no_resource_context_id(): void
+    {
+
+    }
+}

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/ResourceMineConstructionHasBeenFinishedEventSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/ResourceMineConstructionHasBeenFinishedEventSpec.php
@@ -5,26 +5,40 @@ declare(strict_types=1);
 namespace spec\TheGame\Application\Component\BuildingConstruction\Domain\Event;
 
 use PhpSpec\ObjectBehavior;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
 
 final class ResourceMineConstructionHasBeenFinishedEventSpec extends ObjectBehavior
 {
+    public function let(): void
+    {
+        $planetId = "6B685A5A-E279-4E8D-A9D4-0EEC6E7F0F3D";
+        $level = 1;
+        $resourceContextId = "F8214FC4-B5E8-4D19-8360-8E95BE8FBF9B";
+
+        $this->beConstructedWith(
+            $planetId,
+            $resourceContextId,
+            $level,
+        );
+    }
+
     public function it_has_planet_id(): void
     {
-
+        $this->getPlanetId()->shouldReturn("6B685A5A-E279-4E8D-A9D4-0EEC6E7F0F3D");
     }
 
     public function it_has_building_type(): void
     {
-
+        $this->getBuildingType()->shouldReturn(BuildingType::ResourceMine->value);
     }
 
     public function it_has_current_level(): void
     {
-
+        $this->getLevel()->shouldReturn(1);
     }
 
     public function it_has_resource_context_id(): void
     {
-
+        $this->getResourceContextId()->shouldReturn("F8214FC4-B5E8-4D19-8360-8E95BE8FBF9B");
     }
 }

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/ResourceStorageConstructionHasBeenFinishedEventSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/ResourceStorageConstructionHasBeenFinishedEventSpec.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\BuildingConstruction\Domain\Event;
+
+use PhpSpec\ObjectBehavior;
+
+final class ResourceStorageConstructionHasBeenFinishedEventSpec extends ObjectBehavior
+{
+    public function it_has_planet_id(): void
+    {
+
+    }
+
+    public function it_has_building_type(): void
+    {
+
+    }
+
+    public function it_has_current_level(): void
+    {
+
+    }
+
+    public function it_has_resource_context_id(): void
+    {
+
+    }
+
+    public function it_has_no_resource_context_id(): void
+    {
+
+    }
+}

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/ResourceStorageConstructionHasBeenFinishedEventSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/ResourceStorageConstructionHasBeenFinishedEventSpec.php
@@ -5,26 +5,40 @@ declare(strict_types=1);
 namespace spec\TheGame\Application\Component\BuildingConstruction\Domain\Event;
 
 use PhpSpec\ObjectBehavior;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
 
 final class ResourceStorageConstructionHasBeenFinishedEventSpec extends ObjectBehavior
 {
+    public function let(): void
+    {
+        $planetId = "6B685A5A-E279-4E8D-A9D4-0EEC6E7F0F3D";
+        $level = 1;
+        $resourceContextId = "F8214FC4-B5E8-4D19-8360-8E95BE8FBF9B";
+
+        $this->beConstructedWith(
+            $planetId,
+            $resourceContextId,
+            $level,
+        );
+    }
+
     public function it_has_planet_id(): void
     {
-
+        $this->getPlanetId()->shouldReturn("6B685A5A-E279-4E8D-A9D4-0EEC6E7F0F3D");
     }
 
     public function it_has_building_type(): void
     {
-
+        $this->getBuildingType()->shouldReturn(BuildingType::ResourceStorage->value);
     }
 
     public function it_has_current_level(): void
     {
-
+        $this->getLevel()->shouldReturn(1);
     }
 
     public function it_has_resource_context_id(): void
     {
-
+        $this->getResourceContextId()->shouldReturn("F8214FC4-B5E8-4D19-8360-8E95BE8FBF9B");
     }
 }

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/ResourceStorageConstructionHasBeenFinishedEventSpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Event/ResourceStorageConstructionHasBeenFinishedEventSpec.php
@@ -27,9 +27,4 @@ final class ResourceStorageConstructionHasBeenFinishedEventSpec extends ObjectBe
     {
 
     }
-
-    public function it_has_no_resource_context_id(): void
-    {
-
-    }
 }

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Factory/BuildingFactorySpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Factory/BuildingFactorySpec.php
@@ -31,7 +31,7 @@ final class BuildingFactorySpec extends ObjectBehavior
         $buildingType = BuildingType::ResourceMine;
 
         $building = $this->createNew($planetId, $buildingType, $resourceContextId);
-        
+
         $building->getPlanetId()->shouldReturn($planetId);
         $building->getType()->shouldReturn($buildingType);
         $building->getCurrentLevel()->shouldReturn(0);

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Factory/BuildingFactorySpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Factory/BuildingFactorySpec.php
@@ -5,11 +5,35 @@ declare(strict_types=1);
 namespace spec\TheGame\Application\Component\BuildingConstruction\Domain\Factory;
 
 use PhpSpec\ObjectBehavior;
+use TheGame\Application\Component\BuildingConstruction\Domain\BuildingIdInterface;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
+use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
+use TheGame\Application\SharedKernel\Domain\ResourceIdInterface;
+use TheGame\Application\SharedKernel\UuidGeneratorInterface;
 
 final class BuildingFactorySpec extends ObjectBehavior
 {
-    public function it_creates_new_building(): void
-    {
+    public function let(
+        UuidGeneratorInterface $uuidGenerator,
+    ): void {
+        $this->beConstructedWith($uuidGenerator);
+    }
 
+    public function it_creates_new_building(
+        UuidGeneratorInterface $uuidGenerator,
+        BuildingIdInterface $buildingId,
+        PlanetIdInterface $planetId,
+        ResourceIdInterface $resourceContextId,
+    ): void {
+        $uuidGenerator->generateNewBuildingId()
+            ->willReturn($buildingId);
+
+        $buildingType = BuildingType::ResourceMine;
+
+        $building = $this->createNew($planetId, $buildingType, $resourceContextId);
+        
+        $building->getPlanetId()->shouldReturn($planetId);
+        $building->getType()->shouldReturn($buildingType);
+        $building->getCurrentLevel()->shouldReturn(0);
     }
 }

--- a/spec/TheGame/Application/Component/BuildingConstruction/Domain/Factory/BuildingFactorySpec.php
+++ b/spec/TheGame/Application/Component/BuildingConstruction/Domain/Factory/BuildingFactorySpec.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\BuildingConstruction\Domain\Factory;
+
+use PhpSpec\ObjectBehavior;
+
+final class BuildingFactorySpec extends ObjectBehavior
+{
+    public function it_creates_new_building(): void
+    {
+
+    }
+}

--- a/spec/TheGame/Application/Component/ResourceMines/Domain/Entity/MineSpec.php
+++ b/spec/TheGame/Application/Component/ResourceMines/Domain/Entity/MineSpec.php
@@ -22,8 +22,6 @@ final class MineSpec extends ObjectBehavior
             $mineId,
             $resourceId,
             60,
-            60,
-            1.0,
             new DateTimeImmutable("1 second ago"),
         );
 
@@ -40,8 +38,6 @@ final class MineSpec extends ObjectBehavior
             $mineId,
             $resourceId,
             60,
-            60,
-            1.0,
             new DateTimeImmutable("1 second ago"),
         );
 
@@ -60,12 +56,10 @@ final class MineSpec extends ObjectBehavior
             $mineId,
             $resourceId,
             60,
-            60,
-            1.0,
             new DateTimeImmutable("1 second ago"),
         );
 
-        $this->upgradeMiningSpeed();
+        $this->upgradeMiningSpeed(120);
 
         $extractedData = $this->extract();
         $extractedData->shouldHaveType(ResourceAmount::class);
@@ -82,8 +76,6 @@ final class MineSpec extends ObjectBehavior
             $mineId,
             $resourceId,
             60,
-            60,
-            1.0,
             new DateTimeImmutable("10 seconds ago"),
         );
 

--- a/spec/TheGame/Application/Component/ResourceMines/Domain/Entity/MineSpec.php
+++ b/spec/TheGame/Application/Component/ResourceMines/Domain/Entity/MineSpec.php
@@ -65,7 +65,7 @@ final class MineSpec extends ObjectBehavior
             new DateTimeImmutable("1 second ago"),
         );
 
-        $this->upgrade();
+        $this->upgradeMiningSpeed();
 
         $extractedData = $this->extract();
         $extractedData->shouldHaveType(ResourceAmount::class);

--- a/spec/TheGame/Application/Component/ResourceMines/Domain/Entity/MineSpec.php
+++ b/spec/TheGame/Application/Component/ResourceMines/Domain/Entity/MineSpec.php
@@ -84,4 +84,14 @@ final class MineSpec extends ObjectBehavior
         $extractedData->getResourceId()->shouldReturn($resourceId);
         $extractedData->getAmount()->shouldReturn(10);
     }
+
+    public function it_is_for_resource_with_specified_id(): void
+    {
+
+    }
+
+    public function it_is_not_for_resource_with_specified_id(): void
+    {
+
+    }
 }

--- a/spec/TheGame/Application/Component/ResourceMines/Domain/Entity/MineSpec.php
+++ b/spec/TheGame/Application/Component/ResourceMines/Domain/Entity/MineSpec.php
@@ -13,7 +13,7 @@ use TheGame\Application\SharedKernel\Domain\ResourceId;
 
 final class MineSpec extends ObjectBehavior
 {
-    public function it_has_identifier(): void
+    public function let(): void
     {
         $mineId = new MineId("df58a284-9255-4467-8a09-4d9296d6af60");
         $resourceId = new ResourceId("78a71358-a525-48f1-88b4-8280eb3ea4c4");
@@ -24,46 +24,33 @@ final class MineSpec extends ObjectBehavior
             60,
             new DateTimeImmutable("1 second ago"),
         );
+    }
 
+    public function it_has_identifier(): void
+    {
         $this->getId()->shouldHaveType(MineIdInterface::class);
         $this->getId()->getUuid()->shouldBe("df58a284-9255-4467-8a09-4d9296d6af60");
     }
 
     public function it_extracts_resource_amount_on_first_level_from_one_second_delay(): void
     {
-        $mineId = new MineId("df58a284-9255-4467-8a09-4d9296d6af60");
         $resourceId = new ResourceId("78a71358-a525-48f1-88b4-8280eb3ea4c4");
-
-        $this->beConstructedWith(
-            $mineId,
-            $resourceId,
-            60,
-            new DateTimeImmutable("1 second ago"),
-        );
 
         $extractedData = $this->extract();
         $extractedData->shouldHaveType(ResourceAmount::class);
-        $extractedData->getResourceId()->shouldReturn($resourceId);
+        $extractedData->getResourceId()->shouldBeLike($resourceId);
         $extractedData->getAmount()->shouldReturn(1);
     }
 
     public function it_extracts_resource_amount_after_upgrade_from_one_second_delay(): void
     {
-        $mineId = new MineId("df58a284-9255-4467-8a09-4d9296d6af60");
         $resourceId = new ResourceId("78a71358-a525-48f1-88b4-8280eb3ea4c4");
-
-        $this->beConstructedWith(
-            $mineId,
-            $resourceId,
-            60,
-            new DateTimeImmutable("1 second ago"),
-        );
 
         $this->upgradeMiningSpeed(120);
 
         $extractedData = $this->extract();
         $extractedData->shouldHaveType(ResourceAmount::class);
-        $extractedData->getResourceId()->shouldReturn($resourceId);
+        $extractedData->getResourceId()->shouldBeLike($resourceId);
         $extractedData->getAmount()->shouldReturn(2);
     }
 
@@ -87,11 +74,15 @@ final class MineSpec extends ObjectBehavior
 
     public function it_is_for_resource_with_specified_id(): void
     {
+        $resourceId = new ResourceId("78a71358-a525-48f1-88b4-8280eb3ea4c4");
 
+        $this->isForResource($resourceId)->shouldReturn(true);
     }
 
     public function it_is_not_for_resource_with_specified_id(): void
     {
+        $resourceId = new ResourceId("EDE1F927-FEC5-4F79-B982-B7DF05CF36C6");
 
+        $this->isForResource($resourceId)->shouldReturn(false);
     }
 }

--- a/spec/TheGame/Application/Component/ResourceMines/Domain/Entity/MinesCollectionSpec.php
+++ b/spec/TheGame/Application/Component/ResourceMines/Domain/Entity/MinesCollectionSpec.php
@@ -99,4 +99,30 @@ final class MinesCollectionSpec extends ObjectBehavior
         $this->shouldThrow(CannotUpgradeMiningSpeedForUnsupportedResourceException::class)
             ->during('upgradeMiningSpeed', [$resourceId, 500]);
     }
+
+    public function it_has_mine_for_resource(
+        Mine $mine,
+    ): void {
+        $resourceId = "9c1caf31-3fb6-4473-948e-fc63ece22a57";
+        $mine->isForResource(new ResourceId($resourceId))
+            ->willReturn(true);
+
+        $this->addMine($mine);
+
+        $this->hasMineForResource(new ResourceId($resourceId))
+            ->shouldReturn(true);
+    }
+
+    public function it_hasnt_mine_for_resource(
+        Mine $mine,
+    ): void {
+        $resourceId = "9c1caf31-3fb6-4473-948e-fc63ece22a57";
+        $mine->isForResource(new ResourceId($resourceId))
+            ->willReturn(false);
+
+        $this->addMine($mine);
+
+        $this->hasMineForResource(new ResourceId($resourceId))
+            ->shouldReturn(false);
+    }
 }

--- a/spec/TheGame/Application/Component/ResourceMines/Domain/Entity/MinesCollectionSpec.php
+++ b/spec/TheGame/Application/Component/ResourceMines/Domain/Entity/MinesCollectionSpec.php
@@ -6,6 +6,7 @@ namespace spec\TheGame\Application\Component\ResourceMines\Domain\Entity;
 
 use PhpSpec\ObjectBehavior;
 use TheGame\Application\Component\ResourceMines\Domain\Entity\Mine;
+use TheGame\Application\Component\ResourceMines\Domain\Exception\CannotUpgradeMiningSpeedForUnsupportedResourceException;
 use TheGame\Application\Component\ResourceMines\Domain\MinesCollectionId;
 use TheGame\Application\SharedKernel\Domain\PlanetId;
 use TheGame\Application\SharedKernel\Domain\ResourceAmountInterface;
@@ -74,13 +75,28 @@ final class MinesCollectionSpec extends ObjectBehavior
         $extractedResult[1]->getAmount()->shouldReturn(10);
     }
 
-    public function it_upgrades_mining_speed_for_supported_mine(): void
-    {
+    public function it_upgrades_mining_speed_for_supported_mine(
+        Mine $mine,
+    ): void {
+        $this->addMine($mine);
 
+        $resourceId = new ResourceId("91F4327A-8CCF-4D22-95A6-2D2F8E835A14");
+        $mine->isForResource($resourceId)->willReturn(true);
+
+        $mine->upgradeMiningSpeed(500)->shouldBeCalledOnce();
+
+        $this->upgradeMiningSpeed($resourceId, 500);
     }
 
-    public function it_throws_exception_when_upgrading_mining_speed_for_unsupported_mine(): void
-    {
+    public function it_throws_exception_when_upgrading_mining_speed_for_unsupported_mine(
+        Mine $mine,
+    ): void {
+        $this->addMine($mine);
 
+        $resourceId = new ResourceId("91F4327A-8CCF-4D22-95A6-2D2F8E835A14");
+        $mine->isForResource($resourceId)->willReturn(false);
+
+        $this->shouldThrow(CannotUpgradeMiningSpeedForUnsupportedResourceException::class)
+            ->during('upgradeMiningSpeed', [$resourceId, 500]);
     }
 }

--- a/spec/TheGame/Application/Component/ResourceMines/Domain/Entity/MinesCollectionSpec.php
+++ b/spec/TheGame/Application/Component/ResourceMines/Domain/Entity/MinesCollectionSpec.php
@@ -73,4 +73,14 @@ final class MinesCollectionSpec extends ObjectBehavior
         $extractedResult[1]->getResourceId()->getUuid()->shouldReturn("d63a2187-daf5-437f-8586-7fa4e0ef5d7a");
         $extractedResult[1]->getAmount()->shouldReturn(10);
     }
+
+    public function it_upgrades_mining_speed_for_supported_mine(): void
+    {
+
+    }
+
+    public function it_throws_exception_when_upgrading_mining_speed_for_unsupported_mine(): void
+    {
+
+    }
 }

--- a/spec/TheGame/Application/Component/ResourceMines/Domain/Factory/MineFactorySpec.php
+++ b/spec/TheGame/Application/Component/ResourceMines/Domain/Factory/MineFactorySpec.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\ResourceMines\Domain\Factory;
+
+use PhpSpec\ObjectBehavior;
+use TheGame\Application\Component\Balance\Bridge\ResourceMinesContextInterface;
+use TheGame\Application\Component\ResourceMines\Domain\Entity\Mine;
+use TheGame\Application\Component\ResourceMines\Domain\MineIdInterface;
+use TheGame\Application\SharedKernel\Domain\ResourceIdInterface;
+use TheGame\Application\SharedKernel\UuidGeneratorInterface;
+
+final class MineFactorySpec extends ObjectBehavior
+{
+    public function let(
+        UuidGeneratorInterface $uuidGenerator,
+        ResourceMinesContextInterface $resourceMinesContext,
+    ): void {
+        $this->beConstructedWith(
+            $uuidGenerator,
+            $resourceMinesContext,
+        );
+    }
+
+    public function it_creates_new_mine_for_resource(
+        ResourceIdInterface $resourceId,
+        MineIdInterface $mineId,
+        UuidGeneratorInterface $uuidGenerator,
+        ResourceMinesContextInterface $resourceMinesContext,
+    ): void {
+        $uuidGenerator->generateNewMineId()
+            ->willReturn($mineId);
+
+        $resourceMinesContext->getMiningSpeed(1, $resourceId)
+            ->willReturn(500);
+
+        $mine = $this->createNew($resourceId);
+
+        $mine->shouldHaveType(Mine::class);
+        $mine->getId()->shouldReturn($mineId);
+    }
+}

--- a/spec/TheGame/Application/Component/ResourceMines/EventListener/UpgradeMineEventListenerSpec.php
+++ b/spec/TheGame/Application/Component/ResourceMines/EventListener/UpgradeMineEventListenerSpec.php
@@ -7,7 +7,9 @@ namespace spec\TheGame\Application\Component\ResourceMines\EventListener;
 use PhpSpec\ObjectBehavior;
 use TheGame\Application\Component\Balance\Bridge\ResourceMinesContextInterface;
 use TheGame\Application\Component\BuildingConstruction\Domain\Event\ResourceMineConstructionHasBeenFinishedEvent;
+use TheGame\Application\Component\ResourceMines\Domain\Entity\Mine;
 use TheGame\Application\Component\ResourceMines\Domain\Entity\MinesCollection;
+use TheGame\Application\Component\ResourceMines\Domain\Factory\MineFactoryInterface;
 use TheGame\Application\Component\ResourceMines\ResourceMinesRepositoryInterface;
 use TheGame\Application\SharedKernel\Domain\PlanetId;
 use TheGame\Application\SharedKernel\Domain\ResourceId;
@@ -18,10 +20,12 @@ final class UpgradeMineEventListenerSpec extends ObjectBehavior
     public function let(
         ResourceMinesRepositoryInterface $minesRepository,
         ResourceMinesContextInterface $resourceMinesContext,
+        MineFactoryInterface $mineFactory,
     ): void {
         $this->beConstructedWith(
             $minesRepository,
             $resourceMinesContext,
+            $mineFactory,
         );
     }
 
@@ -55,6 +59,45 @@ final class UpgradeMineEventListenerSpec extends ObjectBehavior
 
         $minesRepository->findForPlanet(new PlanetId($planetId))
             ->willReturn($minesCollection);
+
+        $minesCollection->hasMineForResource(new ResourceId($resourceId))
+            ->willReturn(true);
+
+        $resourceMinesContext->getMiningSpeed(2, new ResourceId($resourceId))
+            ->willReturn(700);
+
+        $minesCollection->upgradeMiningSpeed(new ResourceId($resourceId), 700)
+            ->shouldBeCalledOnce();
+
+        $event = new ResourceMineConstructionHasBeenFinishedEvent(
+            $planetId,
+            $resourceId,
+            2
+        );
+        $this->__invoke($event);
+    }
+
+    public function it_creates_mine_when_built_a_new_mine_building(
+        ResourceMinesRepositoryInterface $minesRepository,
+        ResourceMinesContextInterface $resourceMinesContext,
+        MinesCollection $minesCollection,
+        MineFactoryInterface $mineFactory,
+        Mine $mine,
+    ): void {
+        $planetId = "7D5C44D6-0617-4F11-A7A3-76F66B4024E2";
+        $resourceId = "1065CCFF-8111-43CF-9D66-9880FADE72A7";
+
+        $minesRepository->findForPlanet(new PlanetId($planetId))
+            ->willReturn($minesCollection);
+
+        $minesCollection->hasMineForResource(new ResourceId($resourceId))
+            ->willReturn(false);
+
+        $mineFactory->createNew(new ResourceId($resourceId))
+            ->willReturn($mine);
+
+        $minesCollection->addMine($mine)
+            ->shouldBeCalledOnce();
 
         $resourceMinesContext->getMiningSpeed(2, new ResourceId($resourceId))
             ->willReturn(700);

--- a/spec/TheGame/Application/Component/ResourceMines/EventListener/UpgradeMineEventListenerSpec.php
+++ b/spec/TheGame/Application/Component/ResourceMines/EventListener/UpgradeMineEventListenerSpec.php
@@ -24,6 +24,7 @@ final class UpgradeMineEventListenerSpec extends ObjectBehavior
             $resourceMinesContext,
         );
     }
+
     public function it_throws_exception_when_aggregate_is_not_found(
         ResourceMinesRepositoryInterface $minesRepository,
     ): void {
@@ -34,11 +35,13 @@ final class UpgradeMineEventListenerSpec extends ObjectBehavior
             ->willReturn(null);
 
         $event = new ResourceMineConstructionHasBeenFinishedEvent(
-            $planetId, $resourceId, 2
+            $planetId,
+            $resourceId,
+            2
         );
         $this->shouldThrow(InconsistentModelException::class)
             ->during('__invoke', [
-                $event
+                $event,
             ]);
     }
 
@@ -60,7 +63,9 @@ final class UpgradeMineEventListenerSpec extends ObjectBehavior
             ->shouldBeCalledOnce();
 
         $event = new ResourceMineConstructionHasBeenFinishedEvent(
-            $planetId, $resourceId, 2
+            $planetId,
+            $resourceId,
+            2
         );
         $this->__invoke($event);
     }

--- a/spec/TheGame/Application/Component/ResourceMines/EventListener/UpgradeMineEventListenerSpec.php
+++ b/spec/TheGame/Application/Component/ResourceMines/EventListener/UpgradeMineEventListenerSpec.php
@@ -5,16 +5,63 @@ declare(strict_types=1);
 namespace spec\TheGame\Application\Component\ResourceMines\EventListener;
 
 use PhpSpec\ObjectBehavior;
+use TheGame\Application\Component\Balance\Bridge\ResourceMinesContextInterface;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\ResourceMineConstructionHasBeenFinishedEvent;
+use TheGame\Application\Component\ResourceMines\Domain\Entity\MinesCollection;
+use TheGame\Application\Component\ResourceMines\ResourceMinesRepositoryInterface;
+use TheGame\Application\SharedKernel\Domain\PlanetId;
+use TheGame\Application\SharedKernel\Domain\ResourceId;
+use TheGame\Application\SharedKernel\Exception\InconsistentModelException;
 
 final class UpgradeMineEventListenerSpec extends ObjectBehavior
 {
-    public function it_throws_exception_when_aggregate_is_not_found(): void
-    {
+    public function let(
+        ResourceMinesRepositoryInterface $minesRepository,
+        ResourceMinesContextInterface $resourceMinesContext,
+    ): void {
+        $this->beConstructedWith(
+            $minesRepository,
+            $resourceMinesContext,
+        );
+    }
+    public function it_throws_exception_when_aggregate_is_not_found(
+        ResourceMinesRepositoryInterface $minesRepository,
+    ): void {
+        $planetId = "7D5C44D6-0617-4F11-A7A3-76F66B4024E2";
+        $resourceId = "1065CCFF-8111-43CF-9D66-9880FADE72A7";
 
+        $minesRepository->findForPlanet(new PlanetId($planetId))
+            ->willReturn(null);
+
+        $event = new ResourceMineConstructionHasBeenFinishedEvent(
+            $planetId, $resourceId, 2
+        );
+        $this->shouldThrow(InconsistentModelException::class)
+            ->during('__invoke', [
+                $event
+            ]);
     }
 
-    public function it_upgrades_mining_speed(): void
-    {
+    public function it_upgrades_mining_speed(
+        ResourceMinesRepositoryInterface $minesRepository,
+        ResourceMinesContextInterface $resourceMinesContext,
+        MinesCollection $minesCollection,
+    ): void {
+        $planetId = "7D5C44D6-0617-4F11-A7A3-76F66B4024E2";
+        $resourceId = "1065CCFF-8111-43CF-9D66-9880FADE72A7";
 
+        $minesRepository->findForPlanet(new PlanetId($planetId))
+            ->willReturn($minesCollection);
+
+        $resourceMinesContext->getMiningSpeed(2, new ResourceId($resourceId))
+            ->willReturn(700);
+
+        $minesCollection->upgradeMiningSpeed(new ResourceId($resourceId), 700)
+            ->shouldBeCalledOnce();
+
+        $event = new ResourceMineConstructionHasBeenFinishedEvent(
+            $planetId, $resourceId, 2
+        );
+        $this->__invoke($event);
     }
 }

--- a/spec/TheGame/Application/Component/ResourceMines/EventListener/UpgradeMineEventListenerSpec.php
+++ b/spec/TheGame/Application/Component/ResourceMines/EventListener/UpgradeMineEventListenerSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\ResourceMines\EventListener;
+
+use PhpSpec\ObjectBehavior;
+
+final class UpgradeMineEventListenerSpec extends ObjectBehavior
+{
+    public function it_throws_exception_when_aggregate_is_not_found(): void
+    {
+
+    }
+
+    public function it_upgrades_mining_speed(): void
+    {
+
+    }
+}

--- a/spec/TheGame/Application/Component/ResourceStorage/Bridge/ResourceAvailabilityCheckerSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/Bridge/ResourceAvailabilityCheckerSpec.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\ResourceStorage\Bridge;
+
+use PhpSpec\ObjectBehavior;
+
+final class ResourceAvailabilityCheckerSpec extends ObjectBehavior
+{
+    public function it_throws_exception_when_didnt_find_aggregate(): void
+    {
+
+    }
+
+    public function it_returns_true_when_has_enough_resources(): void
+    {
+
+    }
+
+    public function it_returns_false_when_has_enough_resources(): void
+    {
+
+    }
+}

--- a/spec/TheGame/Application/Component/ResourceStorage/Bridge/ResourceAvailabilityCheckerSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/Bridge/ResourceAvailabilityCheckerSpec.php
@@ -5,21 +5,81 @@ declare(strict_types=1);
 namespace spec\TheGame\Application\Component\ResourceStorage\Bridge;
 
 use PhpSpec\ObjectBehavior;
+use TheGame\Application\Component\ResourceStorage\Domain\Entity\StoragesCollection;
+use TheGame\Application\Component\ResourceStorage\Domain\StoragesCollectionIdInterface;
+use TheGame\Application\Component\ResourceStorage\ResourceStoragesRepositoryInterface;
+use TheGame\Application\SharedKernel\Domain\PlanetId;
+use TheGame\Application\SharedKernel\Domain\ResourceAmount;
+use TheGame\Application\SharedKernel\Domain\ResourceAmountInterface;
+use TheGame\Application\SharedKernel\Domain\ResourceId;
+use TheGame\Application\SharedKernel\Domain\ResourceRequirements;
+use TheGame\Application\SharedKernel\Exception\InconsistentModelException;
 
 final class ResourceAvailabilityCheckerSpec extends ObjectBehavior
 {
-    public function it_throws_exception_when_didnt_find_aggregate(): void
-    {
-
+    public function let(
+        ResourceStoragesRepositoryInterface $storagesRepository,
+    ): void {
+        $this->beConstructedWith($storagesRepository);
     }
 
-    public function it_returns_true_when_has_enough_resources(): void
-    {
+    public function it_throws_exception_when_didnt_find_aggregate(
+        ResourceStoragesRepositoryInterface $storagesRepository,
+    ): void {
+        $planetId = "19B1ABC2-8972-4730-8AEA-292AF303E39F";
+        $resourceId = "3222B248-DB8A-4F1C-8F85-7EFAADCADAA0";
 
+        $storagesRepository->findForPlanet(new PlanetId($planetId))
+            ->willReturn(null);
+
+        $requirements = new ResourceRequirements();
+        $resourceAmount = new ResourceAmount(new ResourceId($resourceId), 5);
+        $requirements->add($resourceAmount);
+
+        $this->shouldThrow(InconsistentModelException::class)
+            ->during('check', [
+                new PlanetId($planetId),
+                $requirements,
+            ]);
     }
 
-    public function it_returns_false_when_has_enough_resources(): void
-    {
+    public function it_returns_true_when_has_enough_resources(
+        ResourceStoragesRepositoryInterface $storagesRepository,
+        StoragesCollection $aggregate,
+    ): void {
+        $planetId = "19B1ABC2-8972-4730-8AEA-292AF303E39F";
+        $resourceId = "3222B248-DB8A-4F1C-8F85-7EFAADCADAA0";
 
+        $storagesRepository->findForPlanet(new PlanetId($planetId))
+            ->willReturn($aggregate);
+
+        $requirements = new ResourceRequirements();
+        $resourceAmount = new ResourceAmount(new ResourceId($resourceId), 5);
+        $requirements->add($resourceAmount);
+
+        $aggregate->hasEnough($requirements)->willReturn(true);
+
+        $this->check(new PlanetId($planetId), $requirements)
+            ->shouldReturn(true);
+    }
+
+    public function it_returns_false_when_has_enough_resources(
+        ResourceStoragesRepositoryInterface $storagesRepository,
+        StoragesCollection $aggregate,
+    ): void {
+        $planetId = "19B1ABC2-8972-4730-8AEA-292AF303E39F";
+        $resourceId = "3222B248-DB8A-4F1C-8F85-7EFAADCADAA0";
+
+        $storagesRepository->findForPlanet(new PlanetId($planetId))
+            ->willReturn($aggregate);
+
+        $requirements = new ResourceRequirements();
+        $resourceAmount = new ResourceAmount(new ResourceId($resourceId), 5);
+        $requirements->add($resourceAmount);
+
+        $aggregate->hasEnough($requirements)->willReturn(false);
+
+        $this->check(new PlanetId($planetId), $requirements)
+            ->shouldReturn(false);
     }
 }

--- a/spec/TheGame/Application/Component/ResourceStorage/Bridge/ResourceAvailabilityCheckerSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/Bridge/ResourceAvailabilityCheckerSpec.php
@@ -6,11 +6,9 @@ namespace spec\TheGame\Application\Component\ResourceStorage\Bridge;
 
 use PhpSpec\ObjectBehavior;
 use TheGame\Application\Component\ResourceStorage\Domain\Entity\StoragesCollection;
-use TheGame\Application\Component\ResourceStorage\Domain\StoragesCollectionIdInterface;
 use TheGame\Application\Component\ResourceStorage\ResourceStoragesRepositoryInterface;
 use TheGame\Application\SharedKernel\Domain\PlanetId;
 use TheGame\Application\SharedKernel\Domain\ResourceAmount;
-use TheGame\Application\SharedKernel\Domain\ResourceAmountInterface;
 use TheGame\Application\SharedKernel\Domain\ResourceId;
 use TheGame\Application\SharedKernel\Domain\ResourceRequirements;
 use TheGame\Application\SharedKernel\Exception\InconsistentModelException;

--- a/spec/TheGame/Application/Component/ResourceStorage/Command/UseResourceCommandSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/Command/UseResourceCommandSpec.php
@@ -8,7 +8,7 @@ use PhpSpec\ObjectBehavior;
 use TheGame\Application\Component\ResourceStorage\Exception\InvalidUseAmountException;
 use TheGame\Application\SharedKernel\CommandInterface;
 
-final class UseResourcesCommandSpec extends ObjectBehavior
+final class UseResourceCommandSpec extends ObjectBehavior
 {
     public function let(): void
     {

--- a/spec/TheGame/Application/Component/ResourceStorage/CommandHandler/UseResourceCommandHandlerSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/CommandHandler/UseResourceCommandHandlerSpec.php
@@ -6,7 +6,7 @@ namespace spec\TheGame\Application\Component\ResourceStorage\CommandHandler;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use TheGame\Application\Component\ResourceStorage\Command\UseResourcesCommand;
+use TheGame\Application\Component\ResourceStorage\Command\UseResourceCommand;
 use TheGame\Application\Component\ResourceStorage\Domain\Entity\StoragesCollection;
 use TheGame\Application\Component\ResourceStorage\Domain\Event\StorageAmountHasChangedEvent;
 use TheGame\Application\Component\ResourceStorage\Domain\Exception\CannotUseUnsupportedResourceException;
@@ -18,7 +18,7 @@ use TheGame\Application\SharedKernel\Domain\ResourceId;
 use TheGame\Application\SharedKernel\EventBusInterface;
 use TheGame\Application\SharedKernel\Exception\InconsistentModelException;
 
-final class UseResourcesCommandHandlerSpec extends ObjectBehavior
+final class UseResourceCommandHandlerSpec extends ObjectBehavior
 {
     public function let(
         ResourceStoragesRepositoryInterface $storagesRepository,
@@ -51,7 +51,7 @@ final class UseResourcesCommandHandlerSpec extends ObjectBehavior
 
         $eventBus->dispatch(Argument::type(StorageAmountHasChangedEvent::class))->shouldBeCalledOnce();
 
-        $command = new UseResourcesCommand(
+        $command = new UseResourceCommand(
             $planetId,
             $resourceId,
             $amount
@@ -76,7 +76,7 @@ final class UseResourcesCommandHandlerSpec extends ObjectBehavior
         $storagesCollection->supports($resourceAmount)
             ->willReturn(false);
 
-        $command = new UseResourcesCommand(
+        $command = new UseResourceCommand(
             $planetId,
             $resourceId,
             $amount
@@ -105,7 +105,7 @@ final class UseResourcesCommandHandlerSpec extends ObjectBehavior
         $storagesCollection->hasEnough($resourceAmount)
             ->willReturn(false);
 
-        $command = new UseResourcesCommand(
+        $command = new UseResourceCommand(
             $planetId,
             $resourceId,
             $amount
@@ -124,7 +124,7 @@ final class UseResourcesCommandHandlerSpec extends ObjectBehavior
         $storagesRepository->findForPlanet(new PlanetId($planetId))
             ->willReturn(null);
 
-        $command = new UseResourcesCommand(
+        $command = new UseResourceCommand(
             $planetId,
             $resourceId,
             $amount

--- a/spec/TheGame/Application/Component/ResourceStorage/CommandHandler/UseResourceCommandHandlerSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/CommandHandler/UseResourceCommandHandlerSpec.php
@@ -9,14 +9,12 @@ use Prophecy\Argument;
 use TheGame\Application\Component\ResourceStorage\Command\UseResourceCommand;
 use TheGame\Application\Component\ResourceStorage\Domain\Entity\StoragesCollection;
 use TheGame\Application\Component\ResourceStorage\Domain\Event\StorageAmountHasChangedEvent;
-use TheGame\Application\Component\ResourceStorage\Domain\Exception\CannotUseUnsupportedResourceException;
 use TheGame\Application\Component\ResourceStorage\Domain\Exception\InsufficientResourcesException;
 use TheGame\Application\Component\ResourceStorage\ResourceStoragesRepositoryInterface;
 use TheGame\Application\SharedKernel\Domain\PlanetId;
 use TheGame\Application\SharedKernel\Domain\ResourceAmount;
 use TheGame\Application\SharedKernel\Domain\ResourceId;
 use TheGame\Application\SharedKernel\Domain\ResourceRequirements;
-use TheGame\Application\SharedKernel\Domain\ResourceRequirementsInterface;
 use TheGame\Application\SharedKernel\EventBusInterface;
 use TheGame\Application\SharedKernel\Exception\InconsistentModelException;
 

--- a/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StorageSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StorageSpec.php
@@ -100,8 +100,7 @@ final class StorageSpec extends ObjectBehavior
         $resourceAmount->getAmount()
             ->willReturn(5);
 
-        $planetId = new PlanetId("1ca09e5f-1418-4a53-9df7-d8ecd190e3fd");
-        $this->use($planetId, $resourceAmount);
+        $this->use($resourceAmount);
     }
 
     public function it_throws_exception_when_using_unsupported_resources(

--- a/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StorageSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StorageSpec.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace spec\TheGame\Application\Component\ResourceStorage\Domain\Entity;
 
 use PhpSpec\ObjectBehavior;
+use TheGame\Application\Component\ResourceStorage\Domain\Exception\CannotUpgradeStorageLimitForLowerValueException;
 use TheGame\Application\Component\ResourceStorage\Domain\Exception\CannotUseUnsupportedResourceException;
 use TheGame\Application\Component\ResourceStorage\Domain\Exception\InsufficientResourcesException;
 use TheGame\Application\Component\ResourceStorage\Domain\StorageId;
@@ -183,26 +184,32 @@ final class StorageSpec extends ObjectBehavior
 
     public function it_is_for_resource_with_specified_id(): void
     {
+        $resourceId = "6100ab0e-285b-40ea-a22a-0cbcb7d35421";
 
+        $this->isForResource(new ResourceId($resourceId))->shouldReturn(true);
     }
 
     public function it_is_not_for_resource_with_specified_id(): void
     {
+        $resourceId = "EBEF7262-52CE-45F2-98CD-B122643EE377";
 
+        $this->isForResource(new ResourceId($resourceId))->shouldReturn(false);
     }
 
     public function it_upgrades_limit(): void
     {
-
+        $this->upgradeLimit(200000);
     }
 
     public function it_throws_exception_when_upgrading_limit_but_new_is_lower_than_current(): void
     {
-
+        $this->shouldThrow(CannotUpgradeStorageLimitForLowerValueException::class)
+            ->during('upgradeLimit', [10]);
     }
 
     public function it_throws_exception_when_upgrading_limit_but_new_is_equal_to_current(): void
     {
-
+        $this->shouldThrow(CannotUpgradeStorageLimitForLowerValueException::class)
+            ->during('upgradeLimit', [100000]);
     }
 }

--- a/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StorageSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StorageSpec.php
@@ -180,4 +180,29 @@ final class StorageSpec extends ObjectBehavior
 
         $this->getCurrentAmount()->shouldReturn($limit);
     }
+
+    public function it_is_for_resource_with_specified_id(): void
+    {
+
+    }
+
+    public function it_is_not_for_resource_with_specified_id(): void
+    {
+
+    }
+
+    public function it_upgrades_limit(): void
+    {
+
+    }
+
+    public function it_throws_exception_when_upgrading_limit_but_new_is_lower_than_current(): void
+    {
+
+    }
+
+    public function it_throws_exception_when_upgrading_limit_but_new_is_equal_to_current(): void
+    {
+
+    }
 }

--- a/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StorageSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StorageSpec.php
@@ -9,7 +9,6 @@ use TheGame\Application\Component\ResourceStorage\Domain\Exception\CannotUpgrade
 use TheGame\Application\Component\ResourceStorage\Domain\Exception\CannotUseUnsupportedResourceException;
 use TheGame\Application\Component\ResourceStorage\Domain\Exception\InsufficientResourcesException;
 use TheGame\Application\Component\ResourceStorage\Domain\StorageId;
-use TheGame\Application\SharedKernel\Domain\PlanetId;
 use TheGame\Application\SharedKernel\Domain\ResourceAmountInterface;
 use TheGame\Application\SharedKernel\Domain\ResourceId;
 

--- a/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StorageSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StorageSpec.php
@@ -109,9 +109,8 @@ final class StorageSpec extends ObjectBehavior
         $resourceAmount->getResourceId()
             ->willReturn(new ResourceId("3a58570a-bf32-4bd2-9a65-1fa26567b80b"));
 
-        $planetId = new PlanetId("1ca09e5f-1418-4a53-9df7-d8ecd190e3fd");
         $this->shouldThrow(CannotUseUnsupportedResourceException::class)
-            ->during('use', [$planetId, $resourceAmount]);
+            ->during('use', [$resourceAmount]);
     }
 
     public function it_throws_exception_when_using_more_resources_than_already_have(
@@ -123,9 +122,8 @@ final class StorageSpec extends ObjectBehavior
         $resourceAmount->getAmount()
             ->willReturn(500);
 
-        $planetId = new PlanetId("1ca09e5f-1418-4a53-9df7-d8ecd190e3fd");
         $this->shouldThrow(InsufficientResourcesException::class)
-            ->during('use', [$planetId, $resourceAmount]);
+            ->during('use', [$resourceAmount]);
     }
 
     public function it_dispatches_amount_without_limit_specified(): void

--- a/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StoragesCollectionSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StoragesCollectionSpec.php
@@ -123,8 +123,7 @@ final class StoragesCollectionSpec extends ObjectBehavior
         $storage->hasEnough($resourceAmount)
             ->willReturn(true);
 
-        $planetId = "6100ab0e-285b-40ea-a22a-0cbcb7d35421";
-        $storage->use(new PlanetId($planetId), $resourceAmount)
+        $storage->use($resourceAmount)
             ->shouldBeCalledOnce();
 
         $this->use($resourceAmount);

--- a/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StoragesCollectionSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StoragesCollectionSpec.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use TheGame\Application\Component\ResourceStorage\Domain\Entity\Storage;
+use TheGame\Application\Component\ResourceStorage\Domain\Exception\CannotUpgradeStorageForUnsupportedResourceException;
 use TheGame\Application\Component\ResourceStorage\Domain\Exception\CannotUseUnsupportedResourceException;
 use TheGame\Application\Component\ResourceStorage\Domain\Exception\InsufficientResourcesException;
 use TheGame\Application\Component\ResourceStorage\Domain\StorageCollectionId;
@@ -216,13 +217,31 @@ final class StoragesCollectionSpec extends ObjectBehavior
         $this->dispatch($resourceAmount);
     }
 
-    public function it_upgrades_limit_for_supported_resource(): void
-    {
+    public function it_upgrades_limit_for_supported_resource(
+        Storage $storage,
+    ): void {
+        $resourceId = "a8d6fc51-9f91-4a46-8785-4c6a58464802";
 
+        $this->add($storage);
+
+        $storage->isForResource(new ResourceId($resourceId))
+            ->willReturn(true);
+        $storage->upgradeLimit(1000)->shouldBeCalledOnce();
+
+        $this->upgradeLimit(new ResourceId($resourceId), 1000);
     }
 
-    public function it_throws_exception_when_upgrading_limit_for_unsupported_resource(): void
-    {
+    public function it_throws_exception_when_upgrading_limit_for_unsupported_resource(
+        Storage $storage,
+    ): void {
+        $resourceId = "a8d6fc51-9f91-4a46-8785-4c6a58464802";
 
+        $this->add($storage);
+
+        $storage->isForResource(new ResourceId($resourceId))
+            ->willReturn(false);
+
+        $this->shouldThrow(CannotUpgradeStorageForUnsupportedResourceException::class)
+            ->during('upgradeLimit', [new ResourceId($resourceId), 1000]);
     }
 }

--- a/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StoragesCollectionSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StoragesCollectionSpec.php
@@ -215,4 +215,14 @@ final class StoragesCollectionSpec extends ObjectBehavior
 
         $this->dispatch($resourceAmount);
     }
+
+    public function it_upgrades_limit_for_supported_resource(): void
+    {
+
+    }
+
+    public function it_throws_exception_when_upgrading_limit_for_unsupported_resource(): void
+    {
+
+    }
 }

--- a/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StoragesCollectionSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StoragesCollectionSpec.php
@@ -5,14 +5,17 @@ declare(strict_types=1);
 namespace spec\TheGame\Application\Component\ResourceStorage\Domain\Entity;
 
 use DateTimeImmutable;
+use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use TheGame\Application\Component\ResourceStorage\Domain\Entity\Storage;
 use TheGame\Application\Component\ResourceStorage\Domain\Exception\CannotUseUnsupportedResourceException;
 use TheGame\Application\Component\ResourceStorage\Domain\Exception\InsufficientResourcesException;
 use TheGame\Application\Component\ResourceStorage\Domain\StorageCollectionId;
+use TheGame\Application\Component\ResourceStorage\Domain\StorageId;
 use TheGame\Application\SharedKernel\Domain\PlanetId;
 use TheGame\Application\SharedKernel\Domain\ResourceAmountInterface;
 use TheGame\Application\SharedKernel\Domain\ResourceId;
+use TheGame\Application\SharedKernel\Domain\ResourceRequirementsInterface;
 
 final class StoragesCollectionSpec extends ObjectBehavior
 {
@@ -66,11 +69,16 @@ final class StoragesCollectionSpec extends ObjectBehavior
             ->shouldReturn(false);
     }
 
-    public function it_has_enough_resources_for_resource_amount(
+    public function it_has_enough_resources_for_supported_resources(
         Storage $storage,
         ResourceAmountInterface $resourceAmount,
+        ResourceRequirementsInterface $resourceRequirements,
     ): void {
         $this->add($storage);
+
+        $resourceRequirements->getAll()->willReturn([
+            $resourceAmount->getWrappedObject(),
+        ]);
 
         $storage->supports($resourceAmount)
             ->willReturn(true);
@@ -78,15 +86,20 @@ final class StoragesCollectionSpec extends ObjectBehavior
         $storage->hasEnough($resourceAmount)
             ->willReturn(true);
 
-        $this->hasEnough($resourceAmount)
+        $this->hasEnough($resourceRequirements)
             ->shouldReturn(true);
     }
 
-    public function it_hasnt_enough_resources_for_resource_amount_while_supporting_resource(
+    public function it_hasnt_enough_resources_for_supported_resource(
         Storage $storage,
         ResourceAmountInterface $resourceAmount,
+        ResourceRequirementsInterface $resourceRequirements,
     ): void {
         $this->add($storage);
+
+        $resourceRequirements->getAll()->willReturn([
+            $resourceAmount->getWrappedObject(),
+        ]);
 
         $storage->supports($resourceAmount)
             ->willReturn(true);
@@ -94,20 +107,25 @@ final class StoragesCollectionSpec extends ObjectBehavior
         $storage->hasEnough($resourceAmount)
             ->willReturn(false);
 
-        $this->hasEnough($resourceAmount)
+        $this->hasEnough($resourceRequirements)
             ->shouldReturn(false);
     }
 
-    public function it_hasnt_enough_resources_for_resource_amount_becouse_of_not_supporting_resource(
+    public function it_hasnt_enough_resources_because_of_not_supported_resource(
         Storage $storage,
         ResourceAmountInterface $resourceAmount,
+        ResourceRequirementsInterface $resourceRequirements,
     ): void {
         $this->add($storage);
+
+        $resourceRequirements->getAll()->willReturn([
+            $resourceAmount->getWrappedObject(),
+        ]);
 
         $storage->supports($resourceAmount)
             ->willReturn(false);
 
-        $this->hasEnough($resourceAmount)
+        $this->hasEnough($resourceRequirements)
             ->shouldReturn(false);
     }
 
@@ -159,6 +177,9 @@ final class StoragesCollectionSpec extends ObjectBehavior
             ->willReturn(new ResourceId($resourceId));
         $resourceAmount->getAmount()
             ->willReturn(10);
+
+        $storageId = "65B35793-C142-48E2-A86E-CEEB96584C92";
+        $storage->getId()->willReturn(new StorageId($storageId));
 
         $storage->supports($resourceAmount)
             ->willReturn(true);

--- a/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StoragesCollectionSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StoragesCollectionSpec.php
@@ -243,4 +243,30 @@ final class StoragesCollectionSpec extends ObjectBehavior
         $this->shouldThrow(CannotUpgradeStorageForUnsupportedResourceException::class)
             ->during('upgradeLimit', [new ResourceId($resourceId), 1000]);
     }
+
+    public function it_has_storage_for_resource(
+        Storage $storage,
+    ): void {
+        $resourceId = "a19de2ab-2af9-4f87-a6b5-175d69c5b87a";
+        $storage->isForResource(new ResourceId($resourceId))
+            ->willReturn(true);
+
+        $this->add($storage);
+
+        $this->hasStorageForResource(new ResourceId($resourceId))
+            ->shouldReturn(true);
+    }
+
+    public function it_hasnt_storage_for_resource(
+        Storage $storage,
+    ): void {
+        $resourceId = "a19de2ab-2af9-4f87-a6b5-175d69c5b87a";
+        $storage->isForResource(new ResourceId($resourceId))
+            ->willReturn(false);
+
+        $this->add($storage);
+
+        $this->hasStorageForResource(new ResourceId($resourceId))
+            ->shouldReturn(false);
+    }
 }

--- a/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StoragesCollectionSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/Domain/Entity/StoragesCollectionSpec.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace spec\TheGame\Application\Component\ResourceStorage\Domain\Entity;
 
 use DateTimeImmutable;
-use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use TheGame\Application\Component\ResourceStorage\Domain\Entity\Storage;
 use TheGame\Application\Component\ResourceStorage\Domain\Exception\CannotUpgradeStorageForUnsupportedResourceException;

--- a/spec/TheGame/Application/Component/ResourceStorage/Domain/Factory/StorageFactorySpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/Domain/Factory/StorageFactorySpec.php
@@ -21,7 +21,6 @@ final class StorageFactorySpec extends ObjectBehavior
         ResourceIdInterface $resourceId,
         UuidGeneratorInterface $uuidGenerator,
         StorageIdInterface $storageId,
-        Storage $storage,
     ): void {
         $uuidGenerator->generateNewStorageId()
             ->willReturn($storageId);

--- a/spec/TheGame/Application/Component/ResourceStorage/EventListener/PayForConstructedBuildingListenerSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/EventListener/PayForConstructedBuildingListenerSpec.php
@@ -33,7 +33,9 @@ final class PayForConstructedBuildingListenerSpec extends ObjectBehavior
             "8F474C2C-3AD0-4E27-A6EE-AF09151852C5" => 250,
         ];
         $event = new BuildingConstructionHasBeenStartedEvent(
-            $planetId, $buildingType, $resourceRequirements
+            $planetId,
+            $buildingType,
+            $resourceRequirements
         );
         $this->__invoke($event);
     }

--- a/spec/TheGame/Application/Component/ResourceStorage/EventListener/PayForConstructedBuildingListenerSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/EventListener/PayForConstructedBuildingListenerSpec.php
@@ -5,11 +5,36 @@ declare(strict_types=1);
 namespace spec\TheGame\Application\Component\ResourceStorage\EventListener;
 
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\BuildingConstructionHasBeenStartedEvent;
+use TheGame\Application\Component\ResourceStorage\Command\UseResourceCommand;
+use TheGame\Application\SharedKernel\CommandBusInterface;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
 
 final class PayForConstructedBuildingListenerSpec extends ObjectBehavior
 {
-    public function it_creates_command_for_each_resource_requirement(): void
-    {
+    public function let(
+        CommandBusInterface $commandBus
+    ): void {
+        $this->beConstructedWith($commandBus);
+    }
 
+    public function it_creates_command_for_each_resource_requirement(
+        CommandBusInterface $commandBus
+    ): void {
+        $planetId = "DF3A7B29-6D32-4EBC-AC9D-7FD3939A6E47";
+        $buildingType = BuildingType::ResourceStorage->value;
+
+        $commandBus->dispatch(Argument::type(UseResourceCommand::class))
+            ->shouldBeCalled(2);
+
+        $resourceRequirements = [
+            "A606A1AA-CA42-4771-A641-312028ED415D" => 500,
+            "8F474C2C-3AD0-4E27-A6EE-AF09151852C5" => 250,
+        ];
+        $event = new BuildingConstructionHasBeenStartedEvent(
+            $planetId, $buildingType, $resourceRequirements
+        );
+        $this->__invoke($event);
     }
 }

--- a/spec/TheGame/Application/Component/ResourceStorage/EventListener/PayForConstructedBuildingListenerSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/EventListener/PayForConstructedBuildingListenerSpec.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\ResourceStorage\EventListener;
+
+use PhpSpec\ObjectBehavior;
+
+final class PayForConstructedBuildingListenerSpec extends ObjectBehavior
+{
+    public function it_creates_command_for_each_resource_requirement(): void
+    {
+
+    }
+}

--- a/spec/TheGame/Application/Component/ResourceStorage/EventListener/RefundForCancelledBuildingConstructionListenerSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/EventListener/RefundForCancelledBuildingConstructionListenerSpec.php
@@ -20,8 +20,7 @@ final class RefundForCancelledBuildingConstructionListenerSpec extends ObjectBeh
 
     public function it_creates_command_for_each_resource_requirement(
         CommandBusInterface $commandBus,
-    ): void
-    {
+    ): void {
         $planetId = "DF3A7B29-6D32-4EBC-AC9D-7FD3939A6E47";
         $buildingType = BuildingType::ResourceStorage->value;
 
@@ -33,7 +32,9 @@ final class RefundForCancelledBuildingConstructionListenerSpec extends ObjectBeh
             "8F474C2C-3AD0-4E27-A6EE-AF09151852C5" => 250,
         ];
         $event = new BuildingConstructionHasBeenCancelledEvent(
-            $planetId, $buildingType, $resourceRequirements
+            $planetId,
+            $buildingType,
+            $resourceRequirements
         );
         $this->__invoke($event);
     }

--- a/spec/TheGame/Application/Component/ResourceStorage/EventListener/RefundForCancelledBuildingConstructionListenerSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/EventListener/RefundForCancelledBuildingConstructionListenerSpec.php
@@ -5,11 +5,36 @@ declare(strict_types=1);
 namespace spec\TheGame\Application\Component\ResourceStorage\EventListener;
 
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\BuildingConstructionHasBeenCancelledEvent;
+use TheGame\Application\Component\ResourceStorage\Command\DispatchResourcesCommand;
+use TheGame\Application\SharedKernel\CommandBusInterface;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
 
 final class RefundForCancelledBuildingConstructionListenerSpec extends ObjectBehavior
 {
-    public function it_creates_command_for_each_resource_requirement(): void
+    public function let(CommandBusInterface $commandBus): void
     {
+        $this->beConstructedWith($commandBus);
+    }
 
+    public function it_creates_command_for_each_resource_requirement(
+        CommandBusInterface $commandBus,
+    ): void
+    {
+        $planetId = "DF3A7B29-6D32-4EBC-AC9D-7FD3939A6E47";
+        $buildingType = BuildingType::ResourceStorage->value;
+
+        $commandBus->dispatch(Argument::type(DispatchResourcesCommand::class))
+            ->shouldBeCalled(2);
+
+        $resourceRequirements = [
+            "A606A1AA-CA42-4771-A641-312028ED415D" => 500,
+            "8F474C2C-3AD0-4E27-A6EE-AF09151852C5" => 250,
+        ];
+        $event = new BuildingConstructionHasBeenCancelledEvent(
+            $planetId, $buildingType, $resourceRequirements
+        );
+        $this->__invoke($event);
     }
 }

--- a/spec/TheGame/Application/Component/ResourceStorage/EventListener/RefundForCancelledBuildingConstructionListenerSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/EventListener/RefundForCancelledBuildingConstructionListenerSpec.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\ResourceStorage\EventListener;
+
+use PhpSpec\ObjectBehavior;
+
+final class RefundForCancelledBuildingConstructionListenerSpec extends ObjectBehavior
+{
+    public function it_creates_command_for_each_resource_requirement(): void
+    {
+
+    }
+}

--- a/spec/TheGame/Application/Component/ResourceStorage/EventListener/UpgradeStorageEventListenerSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/EventListener/UpgradeStorageEventListenerSpec.php
@@ -24,6 +24,7 @@ final class UpgradeStorageEventListenerSpec extends ObjectBehavior
             $resourceStoragesContext
         );
     }
+
     public function it_throws_exception_when_aggregate_is_not_found(
         ResourceStoragesRepositoryInterface $storagesRepository,
     ): void {
@@ -35,11 +36,13 @@ final class UpgradeStorageEventListenerSpec extends ObjectBehavior
         $resourceContextId = "0F8DC0DB-766C-4D04-998B-1D9A86FC7A7C";
         $currentLevel = 5;
         $event = new ResourceStorageConstructionHasBeenFinishedEvent(
-            $planetId, $resourceContextId, $currentLevel
+            $planetId,
+            $resourceContextId,
+            $currentLevel
         );
         $this->shouldThrow(InconsistentModelException::class)
             ->during('__invoke', [
-                $event
+                $event,
             ]);
     }
 
@@ -62,7 +65,9 @@ final class UpgradeStorageEventListenerSpec extends ObjectBehavior
             ->shouldBeCalledOnce();
 
         $event = new ResourceStorageConstructionHasBeenFinishedEvent(
-            $planetId, $resourceContextId, $currentLevel
+            $planetId,
+            $resourceContextId,
+            $currentLevel
         );
 
         $this->__invoke($event);

--- a/spec/TheGame/Application/Component/ResourceStorage/EventListener/UpgradeStorageEventListenerSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/EventListener/UpgradeStorageEventListenerSpec.php
@@ -5,16 +5,66 @@ declare(strict_types=1);
 namespace spec\TheGame\Application\Component\ResourceStorage\EventListener;
 
 use PhpSpec\ObjectBehavior;
+use TheGame\Application\Component\Balance\Bridge\ResourceStoragesContextInterface;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\ResourceStorageConstructionHasBeenFinishedEvent;
+use TheGame\Application\Component\ResourceStorage\Domain\Entity\StoragesCollection;
+use TheGame\Application\Component\ResourceStorage\ResourceStoragesRepositoryInterface;
+use TheGame\Application\SharedKernel\Domain\PlanetId;
+use TheGame\Application\SharedKernel\Domain\ResourceId;
+use TheGame\Application\SharedKernel\Exception\InconsistentModelException;
 
 final class UpgradeStorageEventListenerSpec extends ObjectBehavior
 {
-    public function it_throws_exception_when_aggregate_is_not_found(): void
-    {
+    public function let(
+        ResourceStoragesRepositoryInterface $storagesRepository,
+        ResourceStoragesContextInterface $resourceStoragesContext,
+    ): void {
+        $this->beConstructedWith(
+            $storagesRepository,
+            $resourceStoragesContext
+        );
+    }
+    public function it_throws_exception_when_aggregate_is_not_found(
+        ResourceStoragesRepositoryInterface $storagesRepository,
+    ): void {
+        $planetId = "4DF55530-FFF2-439C-B616-41C8244C596C";
 
+        $storagesRepository->findForPlanet(new PlanetId($planetId))
+            ->willReturn(null);
+
+        $resourceContextId = "0F8DC0DB-766C-4D04-998B-1D9A86FC7A7C";
+        $currentLevel = 5;
+        $event = new ResourceStorageConstructionHasBeenFinishedEvent(
+            $planetId, $resourceContextId, $currentLevel
+        );
+        $this->shouldThrow(InconsistentModelException::class)
+            ->during('__invoke', [
+                $event
+            ]);
     }
 
-    public function it_upgrades_storage_limit(): void
-    {
+    public function it_upgrades_storage_limit(
+        ResourceStoragesRepositoryInterface $storagesRepository,
+        ResourceStoragesContextInterface $resourceStoragesContext,
+        StoragesCollection $storagesCollection,
+    ): void {
+        $planetId = "4DF55530-FFF2-439C-B616-41C8244C596C";
+        $resourceContextId = "0F8DC0DB-766C-4D04-998B-1D9A86FC7A7C";
+        $currentLevel = 5;
 
+        $storagesRepository->findForPlanet(new PlanetId($planetId))
+            ->willReturn($storagesCollection);
+
+        $resourceStoragesContext->getLimit($currentLevel, new ResourceId($resourceContextId))
+            ->willReturn(500);
+
+        $storagesCollection->upgradeLimit(new ResourceId($resourceContextId), 500)
+            ->shouldBeCalledOnce();
+
+        $event = new ResourceStorageConstructionHasBeenFinishedEvent(
+            $planetId, $resourceContextId, $currentLevel
+        );
+
+        $this->__invoke($event);
     }
 }

--- a/spec/TheGame/Application/Component/ResourceStorage/EventListener/UpgradeStorageEventListenerSpec.php
+++ b/spec/TheGame/Application/Component/ResourceStorage/EventListener/UpgradeStorageEventListenerSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\TheGame\Application\Component\ResourceStorage\EventListener;
+
+use PhpSpec\ObjectBehavior;
+
+final class UpgradeStorageEventListenerSpec extends ObjectBehavior
+{
+    public function it_throws_exception_when_aggregate_is_not_found(): void
+    {
+
+    }
+
+    public function it_upgrades_storage_limit(): void
+    {
+
+    }
+}

--- a/src/Application/Component/Balance/Bridge/BuildingContextInterface.php
+++ b/src/Application/Component/Balance/Bridge/BuildingContextInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\Balance\Bridge;
+
+use TheGame\Application\SharedKernel\Domain\BuildingType;
+use TheGame\Application\SharedKernel\Domain\ResourceRequirementsInterface;
+
+interface BuildingContextInterface
+{
+    public function getBuildingDuration(
+        int $level,
+        BuildingType $buildingType
+    ): int;
+
+    public function getResourceRequirements(
+        int $level,
+        BuildingType $buildingType
+    ): ResourceRequirementsInterface;
+}

--- a/src/Application/Component/Balance/Bridge/ResourceMinesContextInterface.php
+++ b/src/Application/Component/Balance/Bridge/ResourceMinesContextInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\Balance\Bridge;
+
+use TheGame\Application\SharedKernel\Domain\ResourceIdInterface;
+
+interface ResourceMinesContextInterface
+{
+    public function getMiningSpeed(int $level, ResourceIdInterface $resourceId): int;
+}

--- a/src/Application/Component/Balance/Bridge/ResourceStoragesContextInterface.php
+++ b/src/Application/Component/Balance/Bridge/ResourceStoragesContextInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\Balance\Bridge;
+
+use TheGame\Application\SharedKernel\Domain\ResourceIdInterface;
+
+interface ResourceStoragesContextInterface
+{
+    public function getLimit(int $level, ResourceIdInterface $resourceId): int;
+}

--- a/src/Application/Component/BuildingConstruction/BuildingRepositoryInterface.php
+++ b/src/Application/Component/BuildingConstruction/BuildingRepositoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction;
+
+use TheGame\Application\Component\BuildingConstruction\Domain\BuildingType;
+use TheGame\Application\Component\BuildingConstruction\Domain\Entity\Building;
+use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
+
+interface BuildingRepositoryInterface
+{
+    public function findForPlanet(
+        PlanetIdInterface $planetId,
+        BuildingType $buildingType,
+    ): ?Building;
+}

--- a/src/Application/Component/BuildingConstruction/BuildingRepositoryInterface.php
+++ b/src/Application/Component/BuildingConstruction/BuildingRepositoryInterface.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace TheGame\Application\Component\BuildingConstruction;
 
-use TheGame\Application\Component\BuildingConstruction\Domain\BuildingType;
 use TheGame\Application\Component\BuildingConstruction\Domain\Entity\Building;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
 use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
 
 interface BuildingRepositoryInterface

--- a/src/Application/Component/BuildingConstruction/Command/CancelConstructingCommand.php
+++ b/src/Application/Component/BuildingConstruction/Command/CancelConstructingCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Command;
+
+use TheGame\Application\SharedKernel\CommandInterface;
+
+final class CancelConstructingCommand implements CommandInterface
+{
+    public function __construct(
+        private readonly string $planetId,
+        private readonly string $buildingType,
+    ) {
+    }
+
+    public function getPlanetId(): string
+    {
+        return $this->planetId;
+    }
+
+    public function getBuildingType(): string
+    {
+        return $this->buildingType;
+    }
+}

--- a/src/Application/Component/BuildingConstruction/Command/FinishConstructingCommand.php
+++ b/src/Application/Component/BuildingConstruction/Command/FinishConstructingCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Command;
+
+use TheGame\Application\SharedKernel\CommandInterface;
+
+final class FinishConstructingCommand implements CommandInterface
+{
+    public function __construct(
+        private readonly string $planetId,
+        private readonly string $buildingType,
+    ) {
+    }
+
+    public function getPlanetId(): string
+    {
+        return $this->planetId;
+    }
+
+    public function getBuildingType(): string
+    {
+        return $this->buildingType;
+    }
+}

--- a/src/Application/Component/BuildingConstruction/Command/StartConstructingCommand.php
+++ b/src/Application/Component/BuildingConstruction/Command/StartConstructingCommand.php
@@ -11,6 +11,7 @@ final class StartConstructingCommand implements CommandInterface
     public function __construct(
         private readonly string $planetId,
         private readonly string $buildingType,
+        private readonly ?string $resourceContextId = null,
     ) {
     }
 
@@ -22,5 +23,10 @@ final class StartConstructingCommand implements CommandInterface
     public function getBuildingType(): string
     {
         return $this->buildingType;
+    }
+
+    public function getResourceContextId(): ?string
+    {
+        return $this->resourceContextId;
     }
 }

--- a/src/Application/Component/BuildingConstruction/Command/StartConstructingCommand.php
+++ b/src/Application/Component/BuildingConstruction/Command/StartConstructingCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Command;
+
+use TheGame\Application\SharedKernel\CommandInterface;
+
+final class StartConstructingCommand implements CommandInterface
+{
+    public function __construct(
+        private readonly string $planetId,
+        private readonly string $buildingType,
+    ) {
+    }
+
+    public function getPlanetId(): string
+    {
+        return $this->planetId;
+    }
+
+    public function getBuildingType(): string
+    {
+        return $this->buildingType;
+    }
+}

--- a/src/Application/Component/BuildingConstruction/CommandHandler/CancelConstructingCommandHandler.php
+++ b/src/Application/Component/BuildingConstruction/CommandHandler/CancelConstructingCommandHandler.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace TheGame\Application\Component\BuildingConstruction\CommandHandler;
 
 use TheGame\Application\Component\BuildingConstruction\BuildingRepositoryInterface;
-use TheGame\Application\Component\BuildingConstruction\Command\FinishConstructingCommand;
+use TheGame\Application\Component\BuildingConstruction\Command\CancelConstructingCommand;
 use TheGame\Application\Component\BuildingConstruction\Domain\BuildingType;
-use TheGame\Application\Component\BuildingConstruction\Domain\Event\BuildingConstructionHasBeenFinishedEvent;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\BuildingConstructionHasBeenCancelledEvent;
 use TheGame\Application\Component\BuildingConstruction\Domain\Exception\BuildingHasNotBeenBuiltYetFoundException;
 use TheGame\Application\SharedKernel\Domain\PlanetId;
 use TheGame\Application\SharedKernel\EventBusInterface;
 
-final class FinishConstructingCommandHandler
+final class CancelConstructingCommandHandler
 {
     public function __construct(
         private readonly BuildingRepositoryInterface $buildingRepository,
@@ -20,7 +20,7 @@ final class FinishConstructingCommandHandler
     ) {
     }
 
-    public function __invoke(FinishConstructingCommand $command): void
+    public function __invoke(CancelConstructingCommand $command): void
     {
         $planetId = new PlanetId($command->getPlanetId());
         $buildingType = new BuildingType($command->getBuildingType());
@@ -33,9 +33,9 @@ final class FinishConstructingCommandHandler
             );
         }
 
-        $building->finishUpgrading();
+        $building->cancelUpgrading();
 
-        $event = new BuildingConstructionHasBeenFinishedEvent(
+        $event = new BuildingConstructionHasBeenCancelledEvent(
             $command->getPlanetId(),
             $command->getBuildingType(),
         );

--- a/src/Application/Component/BuildingConstruction/CommandHandler/CancelConstructingCommandHandler.php
+++ b/src/Application/Component/BuildingConstruction/CommandHandler/CancelConstructingCommandHandler.php
@@ -6,9 +6,9 @@ namespace TheGame\Application\Component\BuildingConstruction\CommandHandler;
 
 use TheGame\Application\Component\BuildingConstruction\BuildingRepositoryInterface;
 use TheGame\Application\Component\BuildingConstruction\Command\CancelConstructingCommand;
-use TheGame\Application\Component\BuildingConstruction\Domain\BuildingType;
 use TheGame\Application\Component\BuildingConstruction\Domain\Event\BuildingConstructionHasBeenCancelledEvent;
 use TheGame\Application\Component\BuildingConstruction\Domain\Exception\BuildingHasNotBeenBuiltYetFoundException;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
 use TheGame\Application\SharedKernel\Domain\PlanetId;
 use TheGame\Application\SharedKernel\EventBusInterface;
 

--- a/src/Application/Component/BuildingConstruction/CommandHandler/FinishConstructingCommandHandler.php
+++ b/src/Application/Component/BuildingConstruction/CommandHandler/FinishConstructingCommandHandler.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\CommandHandler;
+
+use TheGame\Application\Component\BuildingConstruction\Command\FinishConstructingCommand;
+
+final class FinishConstructingCommandHandler
+{
+    public function __invoke(FinishConstructingCommand $command): void
+    {
+
+    }
+}

--- a/src/Application/Component/BuildingConstruction/CommandHandler/FinishConstructingCommandHandler.php
+++ b/src/Application/Component/BuildingConstruction/CommandHandler/FinishConstructingCommandHandler.php
@@ -6,9 +6,9 @@ namespace TheGame\Application\Component\BuildingConstruction\CommandHandler;
 
 use TheGame\Application\Component\BuildingConstruction\BuildingRepositoryInterface;
 use TheGame\Application\Component\BuildingConstruction\Command\FinishConstructingCommand;
-use TheGame\Application\Component\BuildingConstruction\Domain\BuildingType;
 use TheGame\Application\Component\BuildingConstruction\Domain\Event\BuildingConstructionHasBeenFinishedEvent;
 use TheGame\Application\Component\BuildingConstruction\Domain\Exception\BuildingHasNotBeenBuiltYetFoundException;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
 use TheGame\Application\SharedKernel\Domain\PlanetId;
 use TheGame\Application\SharedKernel\EventBusInterface;
 

--- a/src/Application/Component/BuildingConstruction/CommandHandler/FinishConstructingCommandHandler.php
+++ b/src/Application/Component/BuildingConstruction/CommandHandler/FinishConstructingCommandHandler.php
@@ -6,7 +6,7 @@ namespace TheGame\Application\Component\BuildingConstruction\CommandHandler;
 
 use TheGame\Application\Component\BuildingConstruction\BuildingRepositoryInterface;
 use TheGame\Application\Component\BuildingConstruction\Command\FinishConstructingCommand;
-use TheGame\Application\Component\BuildingConstruction\Domain\Event\Factory\BuildingTypeEventFactory;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\Factory\BuildingTypeEventFactoryInterface;
 use TheGame\Application\Component\BuildingConstruction\Domain\Exception\BuildingHasNotBeenBuiltYetFoundException;
 use TheGame\Application\SharedKernel\Domain\BuildingType;
 use TheGame\Application\SharedKernel\Domain\PlanetId;
@@ -17,14 +17,14 @@ final class FinishConstructingCommandHandler
     public function __construct(
         private readonly BuildingRepositoryInterface $buildingRepository,
         private readonly EventBusInterface $eventBus,
-        private readonly BuildingTypeEventFactory $buildingTypeEventFactory,
+        private readonly BuildingTypeEventFactoryInterface $buildingTypeEventFactory,
     ) {
     }
 
     public function __invoke(FinishConstructingCommand $command): void
     {
         $planetId = new PlanetId($command->getPlanetId());
-        $buildingType = BuildingType::fromName($command->getBuildingType());
+        $buildingType = BuildingType::from($command->getBuildingType());
 
         $building = $this->buildingRepository->findForPlanet($planetId, $buildingType);
         if ($building === null) {

--- a/src/Application/Component/BuildingConstruction/CommandHandler/StartConstructingCommandHandler.php
+++ b/src/Application/Component/BuildingConstruction/CommandHandler/StartConstructingCommandHandler.php
@@ -14,6 +14,7 @@ use TheGame\Application\Component\BuildingConstruction\Domain\Factory\BuildingFa
 use TheGame\Application\Component\ResourceStorage\Bridge\ResourceAvailabilityCheckerInterface;
 use TheGame\Application\SharedKernel\Domain\BuildingType;
 use TheGame\Application\SharedKernel\Domain\PlanetId;
+use TheGame\Application\SharedKernel\Domain\ResourceId;
 use TheGame\Application\SharedKernel\EventBusInterface;
 
 final class StartConstructingCommandHandler
@@ -34,9 +35,11 @@ final class StartConstructingCommandHandler
 
         $building = $this->buildingRepository->findForPlanet($planetId, $buildingType);
         if ($building === null) {
+            $resourceContextId = new ResourceId($command->getResourceContextId());
             $building = $this->buildingFactory->createNew(
                 $planetId,
                 $buildingType,
+                $resourceContextId,
             );
         }
 

--- a/src/Application/Component/BuildingConstruction/CommandHandler/StartConstructingCommandHandler.php
+++ b/src/Application/Component/BuildingConstruction/CommandHandler/StartConstructingCommandHandler.php
@@ -35,7 +35,11 @@ final class StartConstructingCommandHandler
 
         $building = $this->buildingRepository->findForPlanet($planetId, $buildingType);
         if ($building === null) {
-            $resourceContextId = new ResourceId($command->getResourceContextId());
+            $resourceContextId = $command->getResourceContextId();
+            if ($resourceContextId !== null) {
+                $resourceContextId = new ResourceId($resourceContextId);
+            }
+
             $building = $this->buildingFactory->createNew(
                 $planetId,
                 $buildingType,

--- a/src/Application/Component/BuildingConstruction/CommandHandler/StartConstructingCommandHandler.php
+++ b/src/Application/Component/BuildingConstruction/CommandHandler/StartConstructingCommandHandler.php
@@ -4,12 +4,54 @@ declare(strict_types=1);
 
 namespace TheGame\Application\Component\BuildingConstruction\CommandHandler;
 
+use TheGame\Application\Component\BuildingConstruction\BuildingRepositoryInterface;
 use TheGame\Application\Component\BuildingConstruction\Command\StartConstructingCommand;
+use TheGame\Application\Component\BuildingConstruction\Domain\BuildingType;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\BuildingConstructionHasBeenStartedEvent;
+use TheGame\Application\Component\BuildingConstruction\Domain\Exception\InsufficientResourcesException;
+use TheGame\Application\Component\BuildingConstruction\Domain\Factory\BuildingFactory;
+use TheGame\Application\Component\ResourceStorage\Bridge\ResourceAvailabilityCheckerInterface;
+use TheGame\Application\SharedKernel\Domain\PlanetId;
+use TheGame\Application\SharedKernel\EventBusInterface;
 
 final class StartConstructingCommandHandler
 {
+    public function __construct(
+        private readonly ResourceAvailabilityCheckerInterface $resourceAvailabilityChecker,
+        private readonly BuildingRepositoryInterface $buildingRepository,
+        private readonly BuildingFactory $buildingFactory,
+        private readonly EventBusInterface $eventBus,
+    ) {
+    }
+
     public function __invoke(StartConstructingCommand $command): void
     {
+        $planetId = new PlanetId($command->getPlanetId());
+        $buildingType = new BuildingType($command->getBuildingType());
 
+        $building = $this->buildingRepository->findForPlanet($planetId, $buildingType);
+        if ($building === null) {
+            $building = $this->buildingFactory->createNew(
+                $planetId,
+                $buildingType,
+            );
+        }
+
+        $hasEnoughResources = $this->resourceAvailabilityChecker->check(
+            $planetId,
+            $building->getCosts(),
+        );
+
+        if ($hasEnoughResources === false) {
+            throw new InsufficientResourcesException($planetId, $buildingType);
+        }
+
+        $building->startUpgrading();
+
+        $event = new BuildingConstructionHasBeenStartedEvent(
+            $command->getPlanetId(),
+            $command->getBuildingType(),
+        );
+        $this->eventBus->dispatch($event);
     }
 }

--- a/src/Application/Component/BuildingConstruction/CommandHandler/StartConstructingCommandHandler.php
+++ b/src/Application/Component/BuildingConstruction/CommandHandler/StartConstructingCommandHandler.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\CommandHandler;
+
+use TheGame\Application\Component\BuildingConstruction\Command\StartConstructingCommand;
+
+final class StartConstructingCommandHandler
+{
+    public function __invoke(StartConstructingCommand $command): void
+    {
+
+    }
+}

--- a/src/Application/Component/BuildingConstruction/CommandHandler/StartConstructingCommandHandler.php
+++ b/src/Application/Component/BuildingConstruction/CommandHandler/StartConstructingCommandHandler.php
@@ -48,7 +48,8 @@ final class StartConstructingCommandHandler
             $building->getType(),
         );
         $hasEnoughResources = $this->resourceAvailabilityChecker->check(
-            $planetId, $resourceRequirements,
+            $planetId,
+            $resourceRequirements,
         );
 
         if ($hasEnoughResources === false) {

--- a/src/Application/Component/BuildingConstruction/Domain/BuildingId.php
+++ b/src/Application/Component/BuildingConstruction/Domain/BuildingId.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Domain;
+
+final class BuildingId implements BuildingIdInterface
+{
+    public function __construct(
+        private readonly string $id,
+    ) {
+    }
+
+    public function getUuid(): string
+    {
+        return $this->id;
+    }
+}

--- a/src/Application/Component/BuildingConstruction/Domain/BuildingIdInterface.php
+++ b/src/Application/Component/BuildingConstruction/Domain/BuildingIdInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Domain;
+
+use TheGame\Application\SharedKernel\UuidInterface;
+
+interface BuildingIdInterface extends UuidInterface
+{
+}

--- a/src/Application/Component/BuildingConstruction/Domain/BuildingType.php
+++ b/src/Application/Component/BuildingConstruction/Domain/BuildingType.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Domain;
+
+use TheGame\Application\Component\BuildingConstruction\Domain\Exception\InvalidBuildingTypeException;
+
+final class BuildingType
+{
+    private const SUPPORTED_TYPES = [
+        'mine',
+    ];
+
+    public function __construct(
+        private readonly string $type,
+    ) {
+        if (in_array($this->type, self::SUPPORTED_TYPES) === false) {
+            throw new InvalidBuildingTypeException($this->type);
+        }
+    }
+
+    public function getValue(): string
+    {
+        return $this->type;
+    }
+}

--- a/src/Application/Component/BuildingConstruction/Domain/Entity/Building.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Entity/Building.php
@@ -30,6 +30,11 @@ class Building
     ) {
     }
 
+    public function getId(): BuildingIdInterface
+    {
+        return $this->buildingId;
+    }
+
     public function getPlanetId(): PlanetIdInterface
     {
         return $this->planetId;

--- a/src/Application/Component/BuildingConstruction/Domain/Entity/Building.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Entity/Building.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace TheGame\Application\Component\BuildingConstruction\Domain\Entity;
 
-use DateTimeInterface;
 use DateTime;
+use DateTimeInterface;
 use TheGame\Application\Component\BuildingConstruction\Domain\BuildingIdInterface;
 use TheGame\Application\Component\BuildingConstruction\Domain\Exception\BuildingIsAlreadyUpgradingException;
 use TheGame\Application\Component\BuildingConstruction\Domain\Exception\BuildingIsNotUpgradingYetException;

--- a/src/Application/Component/BuildingConstruction/Domain/Entity/Building.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Entity/Building.php
@@ -20,13 +20,13 @@ class Building
 
     private bool $duringUpgrade = false;
 
-    private ?DateTimeInterface $finishUpgradeAt;
+    private ?DateTimeInterface $finishUpgradeAt = null;
 
     public function __construct(
         protected readonly PlanetIdInterface $planetId,
         protected readonly BuildingIdInterface $buildingId,
         protected readonly BuildingType $type,
-        protected readonly ResourceIdInterface $resourceContextId,
+        protected readonly ?ResourceIdInterface $resourceContextId = null,
     ) {
     }
 
@@ -98,7 +98,7 @@ class Building
         $this->currentLevel++;
     }
 
-    public function getResourceContextId(): ResourceIdInterface
+    public function getResourceContextId(): ?ResourceIdInterface
     {
         return $this->resourceContextId;
     }

--- a/src/Application/Component/BuildingConstruction/Domain/Entity/Building.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Entity/Building.php
@@ -12,6 +12,7 @@ use TheGame\Application\Component\BuildingConstruction\Domain\Exception\Building
 use TheGame\Application\Component\BuildingConstruction\Domain\Exception\BuildingTimeHasNotPassedException;
 use TheGame\Application\SharedKernel\Domain\BuildingType;
 use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
+use TheGame\Application\SharedKernel\Domain\ResourceIdInterface;
 
 class Building
 {
@@ -25,6 +26,7 @@ class Building
         protected readonly PlanetIdInterface $planetId,
         protected readonly BuildingIdInterface $buildingId,
         protected readonly BuildingType $type,
+        protected readonly ResourceIdInterface $resourceContextId,
     ) {
     }
 
@@ -89,5 +91,10 @@ class Building
         $this->duringUpgrade = false;
         $this->finishUpgradeAt = null;
         $this->currentLevel++;
+    }
+
+    public function getResourceContextId(): ResourceIdInterface
+    {
+        return $this->resourceContextId;
     }
 }

--- a/src/Application/Component/BuildingConstruction/Domain/Entity/Building.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Entity/Building.php
@@ -12,7 +12,6 @@ use TheGame\Application\Component\BuildingConstruction\Domain\Exception\Building
 use TheGame\Application\Component\BuildingConstruction\Domain\Exception\BuildingTimeHasNotPassedException;
 use TheGame\Application\SharedKernel\Domain\BuildingType;
 use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
-use TheGame\Application\SharedKernel\Domain\ResourceRequirementsInterface;
 
 class Building
 {
@@ -27,6 +26,11 @@ class Building
         protected readonly BuildingIdInterface $buildingId,
         protected readonly BuildingType $type,
     ) {
+    }
+
+    public function getPlanetId(): PlanetIdInterface
+    {
+        return $this->planetId;
     }
 
     public function getCurrentLevel(): int

--- a/src/Application/Component/BuildingConstruction/Domain/Entity/Building.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Entity/Building.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Domain\Entity;
+
+use TheGame\Application\Component\BuildingConstruction\Domain\BuildingIdInterface;
+use TheGame\Application\Component\BuildingConstruction\Domain\BuildingType;
+use TheGame\Application\Component\BuildingConstruction\Domain\Exception\BuildingIsAlreadyUpgradingException;
+use TheGame\Application\Component\BuildingConstruction\Domain\Exception\BuildingIsNotUpgradingYetException;
+use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
+use TheGame\Application\SharedKernel\Domain\ResourceRequirementsInterface;
+
+class Building
+{
+    private int $currentLevel = 0;
+
+    private bool $duringUpgrade = false;
+
+    public function __construct(
+        protected readonly PlanetIdInterface $planetId,
+        protected readonly BuildingIdInterface $buildingId,
+        protected readonly BuildingType $type,
+    ) {
+    }
+
+    public function startUpgrading(): void
+    {
+        if ($this->duringUpgrade === true) {
+            throw new BuildingIsAlreadyUpgradingException(
+                $this->planetId,
+                $this->type,
+            );
+        }
+
+        $this->duringUpgrade = true;
+    }
+
+    public function cancelUpgrading(): void
+    {
+        if ($this->duringUpgrade === false) {
+            throw new BuildingIsNotUpgradingYetException(
+                $this->planetId,
+                $this->type,
+            );
+        }
+
+        $this->duringUpgrade = false;
+    }
+
+    public function finishUpgrading(): void
+    {
+        if ($this->duringUpgrade === false) {
+            throw new BuildingIsNotUpgradingYetException(
+                $this->planetId,
+                $this->type,
+            );
+        }
+
+        $this->duringUpgrade = false;
+        $this->currentLevel++;
+    }
+
+    public function getCosts(): ResourceRequirementsInterface
+    {
+    }
+}

--- a/src/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenCancelledEvent.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenCancelledEvent.php
@@ -9,6 +9,7 @@ use TheGame\Application\SharedKernel\EventInterface;
 
 final class BuildingConstructionHasBeenCancelledEvent implements EventInterface
 {
+    /** @phpstan-ignore-next-line The validation is done in constructor */
     public function __construct(
         private readonly string $planetId,
         private readonly string $buildingType,

--- a/src/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenCancelledEvent.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenCancelledEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Domain\Event;
+
+use InvalidArgumentException;
+use TheGame\Application\SharedKernel\EventInterface;
+
+final class BuildingConstructionHasBeenCancelledEvent implements EventInterface
+{
+    public function __construct(
+        private readonly string $planetId,
+        private readonly string $buildingType,
+        private readonly array $resourceRequirements,
+    ) {
+        foreach ($this->resourceRequirements as $key => $value) {
+            if (is_string($key) === false || is_int($value) === false) {
+                throw new InvalidArgumentException('Invalid resource requirements key or value');
+            }
+        }
+    }
+
+    public function getPlanetId(): string
+    {
+        return $this->planetId;
+    }
+
+    public function getBuildingType(): string
+    {
+        return $this->buildingType;
+    }
+
+    /** @return array<string, int> */
+    public function getResourceRequirements(): array
+    {
+        return $this->resourceRequirements;
+    }
+}

--- a/src/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenFinishedEvent.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenFinishedEvent.php
@@ -6,7 +6,7 @@ namespace TheGame\Application\Component\BuildingConstruction\Domain\Event;
 
 use TheGame\Application\SharedKernel\EventInterface;
 
-final class BuildingConstructionHasBeenFinishedEvent implements EventInterface
+class BuildingConstructionHasBeenFinishedEvent implements EventInterface
 {
     public function __construct(
         private readonly string $planetId,

--- a/src/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenFinishedEvent.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenFinishedEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Domain\Event;
+
+use TheGame\Application\SharedKernel\EventInterface;
+
+final class BuildingConstructionHasBeenFinishedEvent implements EventInterface
+{
+    public function __construct(
+        private readonly string $planetId,
+        private readonly string $buildingType,
+    ) {
+    }
+
+    public function getPlanetId(): string
+    {
+        return $this->planetId;
+    }
+
+    public function getBuildingType(): string
+    {
+        return $this->buildingType;
+    }
+}

--- a/src/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenFinishedEvent.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenFinishedEvent.php
@@ -11,6 +11,7 @@ class BuildingConstructionHasBeenFinishedEvent implements EventInterface
     public function __construct(
         private readonly string $planetId,
         private readonly string $buildingType,
+        private readonly int $currentLevel,
     ) {
     }
 
@@ -22,5 +23,10 @@ class BuildingConstructionHasBeenFinishedEvent implements EventInterface
     public function getBuildingType(): string
     {
         return $this->buildingType;
+    }
+
+    public function getLevel(): int
+    {
+        return $this->currentLevel;
     }
 }

--- a/src/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenStartedEvent.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenStartedEvent.php
@@ -9,6 +9,7 @@ use TheGame\Application\SharedKernel\EventInterface;
 
 final class BuildingConstructionHasBeenStartedEvent implements EventInterface
 {
+    /** @phpstan-ignore-next-line The validation is done in constructor */
     public function __construct(
         private readonly string $planetId,
         private readonly string $buildingType,

--- a/src/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenStartedEvent.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/BuildingConstructionHasBeenStartedEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Domain\Event;
+
+use InvalidArgumentException;
+use TheGame\Application\SharedKernel\EventInterface;
+
+final class BuildingConstructionHasBeenStartedEvent implements EventInterface
+{
+    public function __construct(
+        private readonly string $planetId,
+        private readonly string $buildingType,
+        private readonly array $resourceRequirements,
+    ) {
+        foreach ($this->resourceRequirements as $key => $value) {
+            if (is_string($key) === false || is_int($value) === false) {
+                throw new InvalidArgumentException('Invalid resource requirements key or value');
+            }
+        }
+    }
+
+    public function getPlanetId(): string
+    {
+        return $this->planetId;
+    }
+
+    public function getBuildingType(): string
+    {
+        return $this->buildingType;
+    }
+
+    /** @return array<string, int> */
+    public function getResourceRequirements(): array
+    {
+        return $this->resourceRequirements;
+    }
+}

--- a/src/Application/Component/BuildingConstruction/Domain/Event/Factory/BuildingTypeEventFactory.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/Factory/BuildingTypeEventFactory.php
@@ -21,19 +21,22 @@ final class BuildingTypeEventFactory
                 return new ResourceMineConstructionHasBeenFinishedEvent(
                     $building->getPlanetId()->getUuid(),
                     $building->getResourceContextId()->getUuid(),
+                    $building->getCurrentLevel(),
                 );
             }
             case BuildingType::ResourceStorage: {
                 return new ResourceStorageConstructionHasBeenFinishedEvent(
                     $building->getPlanetId()->getUuid(),
                     $building->getResourceContextId()->getUuid(),
+                    $building->getCurrentLevel(),
                 );
             }
         }
 
         return new BuildingConstructionHasBeenFinishedEvent(
             $building->getPlanetId()->getUuid(),
-            $type->value
+            $type->value,
+            $building->getCurrentLevel(),
         );
     }
 }

--- a/src/Application/Component/BuildingConstruction/Domain/Event/Factory/BuildingTypeEventFactory.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/Factory/BuildingTypeEventFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Domain\Event\Factory;
+
+use TheGame\Application\Component\BuildingConstruction\Domain\Entity\Building;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\BuildingConstructionHasBeenFinishedEvent;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\ResourceMineConstructionHasBeenFinishedEvent;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\ResourceStorageConstructionHasBeenFinishedEvent;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
+use TheGame\Application\SharedKernel\EventInterface;
+
+final class BuildingTypeEventFactory
+{
+    public function createConstructingFinishedEvent(Building $building): EventInterface
+    {
+        $type = $building->getType();
+        switch ($type) {
+            case BuildingType::ResourceMine: {
+                return new ResourceMineConstructionHasBeenFinishedEvent(
+                    $building->getPlanetId()->getUuid()
+                );
+            }
+            case BuildingType::ResourceStorage: {
+                return new ResourceStorageConstructionHasBeenFinishedEvent(
+                    $building->getPlanetId()->getUuid()
+                );
+            }
+        }
+
+        return new BuildingConstructionHasBeenFinishedEvent(
+            $building->getPlanetId()->getUuid(), $type->value
+        );
+    }
+}

--- a/src/Application/Component/BuildingConstruction/Domain/Event/Factory/BuildingTypeEventFactory.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/Factory/BuildingTypeEventFactory.php
@@ -9,11 +9,10 @@ use TheGame\Application\Component\BuildingConstruction\Domain\Event\BuildingCons
 use TheGame\Application\Component\BuildingConstruction\Domain\Event\ResourceMineConstructionHasBeenFinishedEvent;
 use TheGame\Application\Component\BuildingConstruction\Domain\Event\ResourceStorageConstructionHasBeenFinishedEvent;
 use TheGame\Application\SharedKernel\Domain\BuildingType;
-use TheGame\Application\SharedKernel\EventInterface;
 
-final class BuildingTypeEventFactory
+final class BuildingTypeEventFactory implements BuildingTypeEventFactoryInterface
 {
-    public function createConstructingFinishedEvent(Building $building): EventInterface
+    public function createConstructingFinishedEvent(Building $building): BuildingConstructionHasBeenFinishedEvent
     {
         $type = $building->getType();
         switch ($type) {

--- a/src/Application/Component/BuildingConstruction/Domain/Event/Factory/BuildingTypeEventFactory.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/Factory/BuildingTypeEventFactory.php
@@ -19,12 +19,14 @@ final class BuildingTypeEventFactory
         switch ($type) {
             case BuildingType::ResourceMine: {
                 return new ResourceMineConstructionHasBeenFinishedEvent(
-                    $building->getPlanetId()->getUuid()
+                    $building->getPlanetId()->getUuid(),
+                    $building->getResourceContextId()->getUuid(),
                 );
             }
             case BuildingType::ResourceStorage: {
                 return new ResourceStorageConstructionHasBeenFinishedEvent(
-                    $building->getPlanetId()->getUuid()
+                    $building->getPlanetId()->getUuid(),
+                    $building->getResourceContextId()->getUuid(),
                 );
             }
         }

--- a/src/Application/Component/BuildingConstruction/Domain/Event/Factory/BuildingTypeEventFactory.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/Factory/BuildingTypeEventFactory.php
@@ -32,7 +32,8 @@ final class BuildingTypeEventFactory
         }
 
         return new BuildingConstructionHasBeenFinishedEvent(
-            $building->getPlanetId()->getUuid(), $type->value
+            $building->getPlanetId()->getUuid(),
+            $type->value
         );
     }
 }

--- a/src/Application/Component/BuildingConstruction/Domain/Event/Factory/BuildingTypeEventFactory.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/Factory/BuildingTypeEventFactory.php
@@ -9,6 +9,7 @@ use TheGame\Application\Component\BuildingConstruction\Domain\Event\BuildingCons
 use TheGame\Application\Component\BuildingConstruction\Domain\Event\ResourceMineConstructionHasBeenFinishedEvent;
 use TheGame\Application\Component\BuildingConstruction\Domain\Event\ResourceStorageConstructionHasBeenFinishedEvent;
 use TheGame\Application\SharedKernel\Domain\BuildingType;
+use TheGame\Application\SharedKernel\Domain\ResourceIdInterface;
 
 final class BuildingTypeEventFactory implements BuildingTypeEventFactoryInterface
 {
@@ -17,16 +18,20 @@ final class BuildingTypeEventFactory implements BuildingTypeEventFactoryInterfac
         $type = $building->getType();
         switch ($type) {
             case BuildingType::ResourceMine: {
+                /** @var ResourceIdInterface $resourceContextId */
+                $resourceContextId = $building->getResourceContextId();
                 return new ResourceMineConstructionHasBeenFinishedEvent(
                     $building->getPlanetId()->getUuid(),
-                    $building->getResourceContextId()->getUuid(),
+                    $resourceContextId->getUuid(),
                     $building->getCurrentLevel(),
                 );
             }
             case BuildingType::ResourceStorage: {
+                /** @var ResourceIdInterface $resourceContextId */
+                $resourceContextId = $building->getResourceContextId();
                 return new ResourceStorageConstructionHasBeenFinishedEvent(
                     $building->getPlanetId()->getUuid(),
-                    $building->getResourceContextId()->getUuid(),
+                    $resourceContextId->getUuid(),
                     $building->getCurrentLevel(),
                 );
             }

--- a/src/Application/Component/BuildingConstruction/Domain/Event/Factory/BuildingTypeEventFactoryInterface.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/Factory/BuildingTypeEventFactoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Domain\Event\Factory;
+
+use TheGame\Application\Component\BuildingConstruction\Domain\Entity\Building;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\BuildingConstructionHasBeenFinishedEvent;
+
+interface BuildingTypeEventFactoryInterface
+{
+    public function createConstructingFinishedEvent(Building $building): BuildingConstructionHasBeenFinishedEvent;
+}

--- a/src/Application/Component/BuildingConstruction/Domain/Event/ResourceMineConstructionHasBeenFinishedEvent.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/ResourceMineConstructionHasBeenFinishedEvent.php
@@ -11,10 +11,18 @@ final class ResourceMineConstructionHasBeenFinishedEvent extends BuildingConstru
 {
     public function __construct(
         private readonly string $planetId,
+        private readonly string $resourceContextId,
+        private readonly int $currentLevel,
     ) {
         return parent::__construct(
             $this->planetId,
-            BuildingType::ResourceMine->value
+            BuildingType::ResourceMine->value,
+            $this->currentLevel,
         );
+    }
+
+    public function getResourceContextId(): string
+    {
+        return $this->resourceContextId;
     }
 }

--- a/src/Application/Component/BuildingConstruction/Domain/Event/ResourceMineConstructionHasBeenFinishedEvent.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/ResourceMineConstructionHasBeenFinishedEvent.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Domain\Event;
+
+use TheGame\Application\SharedKernel\Domain\BuildingType;
+use TheGame\Application\SharedKernel\EventInterface;
+
+final class ResourceMineConstructionHasBeenFinishedEvent extends BuildingConstructionHasBeenFinishedEvent implements EventInterface
+{
+    public function __construct(
+        private readonly string $planetId,
+    ) {
+        return parent::__construct(
+            $this->planetId,
+            BuildingType::ResourceMine->value
+        );
+    }
+}

--- a/src/Application/Component/BuildingConstruction/Domain/Event/ResourceMineConstructionHasBeenFinishedEvent.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/ResourceMineConstructionHasBeenFinishedEvent.php
@@ -14,7 +14,7 @@ final class ResourceMineConstructionHasBeenFinishedEvent extends BuildingConstru
         private readonly string $resourceContextId,
         private readonly int $currentLevel,
     ) {
-        return parent::__construct(
+        parent::__construct(
             $this->planetId,
             BuildingType::ResourceMine->value,
             $this->currentLevel,

--- a/src/Application/Component/BuildingConstruction/Domain/Event/ResourceStorageConstructionHasBeenFinishedEvent.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/ResourceStorageConstructionHasBeenFinishedEvent.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Domain\Event;
+
+use TheGame\Application\SharedKernel\Domain\BuildingType;
+use TheGame\Application\SharedKernel\EventInterface;
+
+final class ResourceStorageConstructionHasBeenFinishedEvent extends BuildingConstructionHasBeenFinishedEvent implements EventInterface
+{
+    public function __construct(
+        private readonly string $planetId,
+    ) {
+        return parent::__construct(
+            $this->planetId,
+            BuildingType::ResourceStorage->value
+        );
+    }
+}

--- a/src/Application/Component/BuildingConstruction/Domain/Event/ResourceStorageConstructionHasBeenFinishedEvent.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/ResourceStorageConstructionHasBeenFinishedEvent.php
@@ -11,10 +11,18 @@ final class ResourceStorageConstructionHasBeenFinishedEvent extends BuildingCons
 {
     public function __construct(
         private readonly string $planetId,
+        private readonly string $resourceContextId,
+        private readonly int $currentLevel,
     ) {
         return parent::__construct(
             $this->planetId,
-            BuildingType::ResourceStorage->value
+            BuildingType::ResourceStorage->value,
+            $this->currentLevel,
         );
+    }
+
+    public function getResourceContextId(): string
+    {
+        return $this->resourceContextId;
     }
 }

--- a/src/Application/Component/BuildingConstruction/Domain/Event/ResourceStorageConstructionHasBeenFinishedEvent.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Event/ResourceStorageConstructionHasBeenFinishedEvent.php
@@ -14,7 +14,7 @@ final class ResourceStorageConstructionHasBeenFinishedEvent extends BuildingCons
         private readonly string $resourceContextId,
         private readonly int $currentLevel,
     ) {
-        return parent::__construct(
+        parent::__construct(
             $this->planetId,
             BuildingType::ResourceStorage->value,
             $this->currentLevel,

--- a/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingHasNotBeenBuiltYetFoundException.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingHasNotBeenBuiltYetFoundException.php
@@ -16,7 +16,7 @@ final class BuildingHasNotBeenBuiltYetFoundException extends DomainException
     ) {
         $message = sprintf(
             'Building with type %s was not built yet on planet %s',
-            $buildingType->getValue(),
+            $buildingType->value,
             $planetId->getUuid(),
         );
 

--- a/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingHasNotBeenBuiltYetFoundException.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingHasNotBeenBuiltYetFoundException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Domain\Exception;
+
+use DomainException;
+use TheGame\Application\Component\BuildingConstruction\Domain\BuildingType;
+use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
+
+final class BuildingHasNotBeenBuiltYetFoundException extends DomainException
+{
+    public function __construct(
+        PlanetIdInterface $planetId,
+        BuildingType $buildingType,
+    ) {
+        $message = sprintf(
+            'Building with type %s was not built yet on planet %s',
+            $buildingType->getValue(),
+            $planetId->getUuid(),
+        );
+
+        parent::__construct($message);
+    }
+}

--- a/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingHasNotBeenBuiltYetFoundException.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingHasNotBeenBuiltYetFoundException.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace TheGame\Application\Component\BuildingConstruction\Domain\Exception;
 
 use DomainException;
-use TheGame\Application\Component\BuildingConstruction\Domain\BuildingType;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
 use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
 
 final class BuildingHasNotBeenBuiltYetFoundException extends DomainException

--- a/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingIsAlreadyUpgradingException.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingIsAlreadyUpgradingException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Domain\Exception;
+
+use DomainException;
+use TheGame\Application\Component\BuildingConstruction\Domain\BuildingType;
+use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
+
+final class BuildingIsAlreadyUpgradingException extends DomainException
+{
+    public function __construct(
+        PlanetIdInterface $planetId,
+        BuildingType $buildingType,
+    ) {
+        $message = sprintf(
+            'Building with type %s is already being upgraded on %s planet',
+            $buildingType->getValue(),
+            $planetId->getUuid(),
+        );
+
+        parent::__construct($message);
+    }
+}

--- a/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingIsAlreadyUpgradingException.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingIsAlreadyUpgradingException.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace TheGame\Application\Component\BuildingConstruction\Domain\Exception;
 
 use DomainException;
-use TheGame\Application\Component\BuildingConstruction\Domain\BuildingType;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
 use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
 
 final class BuildingIsAlreadyUpgradingException extends DomainException

--- a/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingIsAlreadyUpgradingException.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingIsAlreadyUpgradingException.php
@@ -16,7 +16,7 @@ final class BuildingIsAlreadyUpgradingException extends DomainException
     ) {
         $message = sprintf(
             'Building with type %s is already being upgraded on %s planet',
-            $buildingType->getValue(),
+            $buildingType->value,
             $planetId->getUuid(),
         );
 

--- a/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingIsNotUpgradingYetException.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingIsNotUpgradingYetException.php
@@ -16,7 +16,7 @@ final class BuildingIsNotUpgradingYetException extends DomainException
     ) {
         $message = sprintf(
             'Building with type %s is not being upgraded yet on planet %s',
-            $buildingType->getValue(),
+            $buildingType->value,
             $planetId->getUuid(),
         );
 

--- a/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingIsNotUpgradingYetException.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingIsNotUpgradingYetException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Domain\Exception;
+
+use DomainException;
+use TheGame\Application\Component\BuildingConstruction\Domain\BuildingType;
+use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
+
+final class BuildingIsNotUpgradingYetException extends DomainException
+{
+    public function __construct(
+        PlanetIdInterface $planetId,
+        BuildingType $buildingType,
+    ) {
+        $message = sprintf(
+            'Building with type %s is not being upgraded yet on planet %s',
+            $buildingType->getValue(),
+            $planetId->getUuid(),
+        );
+
+        parent::__construct($message);
+    }
+}

--- a/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingTimeHasNotPassedException.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingTimeHasNotPassedException.php
@@ -16,7 +16,7 @@ final class BuildingTimeHasNotPassedException extends DomainException
     ) {
         $message = sprintf(
             'Buildings time with type %s has not passed on planet %s',
-            $buildingType->getValue(),
+            $buildingType->value,
             $planetId->getUuid(),
         );
 

--- a/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingTimeHasNotPassedException.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Exception/BuildingTimeHasNotPassedException.php
@@ -8,14 +8,14 @@ use DomainException;
 use TheGame\Application\SharedKernel\Domain\BuildingType;
 use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
 
-final class BuildingIsNotUpgradingYetException extends DomainException
+final class BuildingTimeHasNotPassedException extends DomainException
 {
     public function __construct(
         PlanetIdInterface $planetId,
         BuildingType $buildingType,
     ) {
         $message = sprintf(
-            'Building with type %s is not being upgraded yet on planet %s',
+            'Buildings time with type %s has not passed on planet %s',
             $buildingType->getValue(),
             $planetId->getUuid(),
         );

--- a/src/Application/Component/BuildingConstruction/Domain/Exception/InsufficientResourcesException.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Exception/InsufficientResourcesException.php
@@ -17,7 +17,7 @@ final class InsufficientResourcesException extends DomainException
         parent::__construct(
             sprintf(
                 'Insufficient resources for constructing building %s on planet %s',
-                $buildingType->getValue(),
+                $buildingType->value,
                 $planetId->getUuid(),
             ),
         );

--- a/src/Application/Component/BuildingConstruction/Domain/Exception/InsufficientResourcesException.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Exception/InsufficientResourcesException.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace TheGame\Application\Component\BuildingConstruction\Domain\Exception;
 
 use DomainException;
-use TheGame\Application\Component\BuildingConstruction\Domain\BuildingType;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
 use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
 
 final class InsufficientResourcesException extends DomainException

--- a/src/Application/Component/BuildingConstruction/Domain/Exception/InsufficientResourcesException.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Exception/InsufficientResourcesException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Domain\Exception;
+
+use DomainException;
+use TheGame\Application\Component\BuildingConstruction\Domain\BuildingType;
+use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
+
+final class InsufficientResourcesException extends DomainException
+{
+    public function __construct(
+        PlanetIdInterface $planetId,
+        BuildingType $buildingType,
+    ) {
+        parent::__construct(
+            sprintf(
+                'Insufficient resources for constructing building %s on planet %s',
+                $buildingType->getValue(),
+                $planetId->getUuid(),
+            ),
+        );
+    }
+}

--- a/src/Application/Component/BuildingConstruction/Domain/Exception/InvalidBuildingTypeException.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Exception/InvalidBuildingTypeException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Domain\Exception;
+
+use DomainException;
+
+final class InvalidBuildingTypeException extends DomainException
+{
+    public function __construct(string $type)
+    {
+        $message = sprintf('Invalid building type %s', $type);
+
+        parent::__construct($message);
+    }
+}

--- a/src/Application/Component/BuildingConstruction/Domain/Factory/BuildingFactory.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Factory/BuildingFactory.php
@@ -7,6 +7,7 @@ namespace TheGame\Application\Component\BuildingConstruction\Domain\Factory;
 use TheGame\Application\Component\BuildingConstruction\Domain\Entity\Building;
 use TheGame\Application\SharedKernel\Domain\BuildingType;
 use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
+use TheGame\Application\SharedKernel\Domain\ResourceIdInterface;
 use TheGame\Application\SharedKernel\UuidGeneratorInterface;
 
 final class BuildingFactory
@@ -19,6 +20,7 @@ final class BuildingFactory
     public function createNew(
         PlanetIdInterface $planetId,
         BuildingType $type,
+        ResourceIdInterface $resourceContextId,
     ): Building {
         $buildingId = $this->uuidGenerator->generateNewBuildingId();
 
@@ -26,6 +28,7 @@ final class BuildingFactory
             $planetId,
             $buildingId,
             $type,
+            $resourceContextId,
         );
     }
 }

--- a/src/Application/Component/BuildingConstruction/Domain/Factory/BuildingFactory.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Factory/BuildingFactory.php
@@ -20,7 +20,7 @@ final class BuildingFactory implements BuildingFactoryInterface
     public function createNew(
         PlanetIdInterface $planetId,
         BuildingType $type,
-        ResourceIdInterface $resourceContextId,
+        ?ResourceIdInterface $resourceContextId,
     ): Building {
         $buildingId = $this->uuidGenerator->generateNewBuildingId();
 

--- a/src/Application/Component/BuildingConstruction/Domain/Factory/BuildingFactory.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Factory/BuildingFactory.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace TheGame\Application\Component\BuildingConstruction\Domain\Factory;
 
-use TheGame\Application\Component\BuildingConstruction\Domain\BuildingType;
 use TheGame\Application\Component\BuildingConstruction\Domain\Entity\Building;
+use TheGame\Application\SharedKernel\Domain\BuildingType;
 use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
 use TheGame\Application\SharedKernel\UuidGeneratorInterface;
 

--- a/src/Application/Component/BuildingConstruction/Domain/Factory/BuildingFactory.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Factory/BuildingFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\BuildingConstruction\Domain\Factory;
+
+use TheGame\Application\Component\BuildingConstruction\Domain\BuildingType;
+use TheGame\Application\Component\BuildingConstruction\Domain\Entity\Building;
+use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
+use TheGame\Application\SharedKernel\UuidGeneratorInterface;
+
+final class BuildingFactory
+{
+    public function __construct(
+        private readonly UuidGeneratorInterface $uuidGenerator,
+    ) {
+    }
+
+    public function createNew(
+        PlanetIdInterface $planetId,
+        BuildingType $type,
+    ): Building {
+        $buildingId = $this->uuidGenerator->generateNewBuildingId();
+
+        return new Building(
+            $planetId,
+            $buildingId,
+            $type,
+        );
+    }
+}

--- a/src/Application/Component/BuildingConstruction/Domain/Factory/BuildingFactoryInterface.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Factory/BuildingFactoryInterface.php
@@ -8,27 +8,12 @@ use TheGame\Application\Component\BuildingConstruction\Domain\Entity\Building;
 use TheGame\Application\SharedKernel\Domain\BuildingType;
 use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
 use TheGame\Application\SharedKernel\Domain\ResourceIdInterface;
-use TheGame\Application\SharedKernel\UuidGeneratorInterface;
 
-final class BuildingFactory implements BuildingFactoryInterface
+interface BuildingFactoryInterface
 {
-    public function __construct(
-        private readonly UuidGeneratorInterface $uuidGenerator,
-    ) {
-    }
-
     public function createNew(
         PlanetIdInterface $planetId,
         BuildingType $type,
         ResourceIdInterface $resourceContextId,
-    ): Building {
-        $buildingId = $this->uuidGenerator->generateNewBuildingId();
-
-        return new Building(
-            $planetId,
-            $buildingId,
-            $type,
-            $resourceContextId,
-        );
-    }
+    ): Building;
 }

--- a/src/Application/Component/BuildingConstruction/Domain/Factory/BuildingFactoryInterface.php
+++ b/src/Application/Component/BuildingConstruction/Domain/Factory/BuildingFactoryInterface.php
@@ -14,6 +14,6 @@ interface BuildingFactoryInterface
     public function createNew(
         PlanetIdInterface $planetId,
         BuildingType $type,
-        ResourceIdInterface $resourceContextId,
+        ?ResourceIdInterface $resourceContextId,
     ): Building;
 }

--- a/src/Application/Component/ResourceMines/Domain/Entity/Mine.php
+++ b/src/Application/Component/ResourceMines/Domain/Entity/Mine.php
@@ -19,7 +19,6 @@ class Mine
         protected int $currentMiningSpeed,
         protected DateTimeInterface $extractedAt,
     ) {
-
     }
 
     public function getId(): MineIdInterface

--- a/src/Application/Component/ResourceMines/Domain/Entity/Mine.php
+++ b/src/Application/Component/ResourceMines/Domain/Entity/Mine.php
@@ -16,9 +16,10 @@ class Mine
     public function __construct(
         protected readonly MineIdInterface $id,
         protected readonly ResourceIdInterface $resourceId,
-        protected float $currentMiningSpeed,
+        protected int $currentMiningSpeed,
         protected DateTimeInterface $extractedAt,
     ) {
+
     }
 
     public function getId(): MineIdInterface

--- a/src/Application/Component/ResourceMines/Domain/Entity/Mine.php
+++ b/src/Application/Component/ResourceMines/Domain/Entity/Mine.php
@@ -19,7 +19,6 @@ class Mine
         protected float $currentMiningSpeed,
         protected DateTimeInterface $extractedAt,
     ) {
-
     }
 
     public function getId(): MineIdInterface

--- a/src/Application/Component/ResourceMines/Domain/Entity/Mine.php
+++ b/src/Application/Component/ResourceMines/Domain/Entity/Mine.php
@@ -13,17 +13,13 @@ use TheGame\Application\SharedKernel\Domain\ResourceIdInterface;
 
 class Mine
 {
-    protected int $currentLevel;
-
     public function __construct(
         protected readonly MineIdInterface $id,
         protected readonly ResourceIdInterface $resourceId,
-        protected float $baseMiningSpeed,
         protected float $currentMiningSpeed,
-        protected float $miningMultiplier,
         protected DateTimeInterface $extractedAt,
     ) {
-        $this->currentLevel = 1;
+
     }
 
     public function getId(): MineIdInterface
@@ -31,10 +27,14 @@ class Mine
         return $this->id;
     }
 
-    public function upgrade(): void
+    public function isForResource(ResourceIdInterface $resourceId): bool
     {
-        $this->currentLevel++;
-        $this->currentMiningSpeed = $this->baseMiningSpeed * $this->miningMultiplier * $this->currentLevel;
+        return $this->resourceId->getUuid() === $resourceId->getUuid();
+    }
+
+    public function upgradeMiningSpeed(int $newSpeed): void
+    {
+        $this->currentMiningSpeed = $newSpeed;
     }
 
     public function extract(): ResourceAmountInterface

--- a/src/Application/Component/ResourceMines/Domain/Entity/MinesCollection.php
+++ b/src/Application/Component/ResourceMines/Domain/Entity/MinesCollection.php
@@ -6,9 +6,11 @@ namespace TheGame\Application\Component\ResourceMines\Domain\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use TheGame\Application\Component\ResourceMines\Domain\Exception\CannotUpgradeMiningSpeedForUnsupportedResourceException;
 use TheGame\Application\Component\ResourceMines\Domain\MinesCollectionIdInterface;
 use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
 use TheGame\Application\SharedKernel\Domain\ResourceAmountInterface;
+use TheGame\Application\SharedKernel\Domain\ResourceIdInterface;
 
 class MinesCollection
 {
@@ -48,5 +50,24 @@ class MinesCollection
         if ($this->mines->contains($mine) === false) {
             $this->mines->add($mine);
         }
+    }
+
+    public function upgradeMiningSpeed(
+        ResourceIdInterface $resourceId,
+        int $newSpeed
+    ): void {
+        foreach ($this->mines as $mine) {
+            if ($mine->isForResource($resourceId) === true) {
+                $mine->upgradeMiningSpeed($newSpeed);
+
+                return;
+            }
+        }
+
+        throw new CannotUpgradeMiningSpeedForUnsupportedResourceException(
+            $this->planetId,
+            $resourceId,
+            $newSpeed
+        );
     }
 }

--- a/src/Application/Component/ResourceMines/Domain/Entity/MinesCollection.php
+++ b/src/Application/Component/ResourceMines/Domain/Entity/MinesCollection.php
@@ -70,4 +70,15 @@ class MinesCollection
             $newSpeed
         );
     }
+
+    public function hasMineForResource(ResourceIdInterface $resourceId): bool
+    {
+        foreach ($this->mines as $mine) {
+            if ($mine->isForResource($resourceId) === true) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Application/Component/ResourceMines/Domain/Exception/CannotUpgradeMiningSpeedForUnsupportedResourceException.php
+++ b/src/Application/Component/ResourceMines/Domain/Exception/CannotUpgradeMiningSpeedForUnsupportedResourceException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\ResourceMines\Domain\Exception;
+
+use DomainException;
+use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
+use TheGame\Application\SharedKernel\Domain\ResourceIdInterface;
+
+final class CannotUpgradeMiningSpeedForUnsupportedResourceException extends DomainException
+{
+    public function __construct(
+        PlanetIdInterface $planetId,
+        ResourceIdInterface $resourceId,
+        int $newSpeed,
+    ) {
+        parent::__construct(
+            sprintf(
+                'Cannot upgrade mining speed to %d for unsupported resource %s on planet %s ',
+                $newSpeed,
+                $planetId->getUuid(),
+                $resourceId->getUuid(),
+            ),
+        );
+    }
+}

--- a/src/Application/Component/ResourceMines/Domain/Factory/MineFactory.php
+++ b/src/Application/Component/ResourceMines/Domain/Factory/MineFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\ResourceMines\Domain\Factory;
+
+use DateTimeImmutable;
+use TheGame\Application\Component\Balance\Bridge\ResourceMinesContextInterface;
+use TheGame\Application\Component\ResourceMines\Domain\Entity\Mine;
+use TheGame\Application\SharedKernel\Domain\ResourceIdInterface;
+use TheGame\Application\SharedKernel\UuidGeneratorInterface;
+
+final class MineFactory implements MineFactoryInterface
+{
+    public function __construct(
+        private readonly UuidGeneratorInterface $uuidGenerator,
+        private readonly ResourceMinesContextInterface $resourceMinesContext,
+    ) {
+    }
+
+    public function createNew(ResourceIdInterface $resourceId): Mine
+    {
+        $mineId = $this->uuidGenerator->generateNewMineId();
+        $initialMiningSpeed = $this->resourceMinesContext->getMiningSpeed(1, $resourceId);
+
+        return new Mine(
+            $mineId,
+            $resourceId,
+            $initialMiningSpeed,
+            new DateTimeImmutable(),
+        );
+    }
+}

--- a/src/Application/Component/ResourceMines/Domain/Factory/MineFactoryInterface.php
+++ b/src/Application/Component/ResourceMines/Domain/Factory/MineFactoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\ResourceMines\Domain\Factory;
+
+use TheGame\Application\Component\ResourceMines\Domain\Entity\Mine;
+use TheGame\Application\SharedKernel\Domain\ResourceIdInterface;
+
+interface MineFactoryInterface
+{
+    public function createNew(ResourceIdInterface $resourceId): Mine;
+}

--- a/src/Application/Component/ResourceMines/EventListener/UpgradeMineEventListener.php
+++ b/src/Application/Component/ResourceMines/EventListener/UpgradeMineEventListener.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\ResourceMines\EventListener;
+
+use TheGame\Application\Component\Balance\Bridge\ResourceMinesContextInterface;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\ResourceMineConstructionHasBeenFinishedEvent;
+use TheGame\Application\Component\ResourceMines\ResourceMinesRepositoryInterface;
+use TheGame\Application\SharedKernel\Domain\PlanetId;
+use TheGame\Application\SharedKernel\Domain\ResourceId;
+use TheGame\Application\SharedKernel\Exception\InconsistentModelException;
+
+final class UpgradeMineEventListener
+{
+    public function __construct(
+        private readonly ResourceMinesRepositoryInterface $minesRepository,
+        private readonly ResourceMinesContextInterface $resourceMinesContext,
+    ) {
+
+    }
+
+    public function __invoke(ResourceMineConstructionHasBeenFinishedEvent $event): void
+    {
+        $planetId = new PlanetId($event->getPlanetId());
+        $minesCollection = $this->minesRepository->findForPlanet($planetId);
+        if ($minesCollection === null) {
+            throw new InconsistentModelException(sprintf("Planet %d has no mines collection attached", $event->getPlanetId()));
+        }
+
+        $resourceId = new ResourceId($event->getResourceContextId());
+        $newMiningSpeed = $this->resourceMinesContext->getMiningSpeed(
+            $event->getLevel(), $resourceId
+        );
+
+        $minesCollection->upgradeMiningSpeed(
+            $resourceId,
+            $newMiningSpeed,
+        );
+    }
+}

--- a/src/Application/Component/ResourceMines/EventListener/UpgradeMineEventListener.php
+++ b/src/Application/Component/ResourceMines/EventListener/UpgradeMineEventListener.php
@@ -6,6 +6,7 @@ namespace TheGame\Application\Component\ResourceMines\EventListener;
 
 use TheGame\Application\Component\Balance\Bridge\ResourceMinesContextInterface;
 use TheGame\Application\Component\BuildingConstruction\Domain\Event\ResourceMineConstructionHasBeenFinishedEvent;
+use TheGame\Application\Component\ResourceMines\Domain\Factory\MineFactoryInterface;
 use TheGame\Application\Component\ResourceMines\ResourceMinesRepositoryInterface;
 use TheGame\Application\SharedKernel\Domain\PlanetId;
 use TheGame\Application\SharedKernel\Domain\ResourceId;
@@ -16,6 +17,7 @@ final class UpgradeMineEventListener
     public function __construct(
         private readonly ResourceMinesRepositoryInterface $minesRepository,
         private readonly ResourceMinesContextInterface $resourceMinesContext,
+        private readonly MineFactoryInterface $resourceMineFactory,
     ) {
     }
 
@@ -25,6 +27,12 @@ final class UpgradeMineEventListener
         $minesCollection = $this->minesRepository->findForPlanet($planetId);
         if ($minesCollection === null) {
             throw new InconsistentModelException(sprintf("Planet %d has no mines collection attached", $event->getPlanetId()));
+        }
+
+        $resourceId = new ResourceId($event->getResourceContextId());
+        if ($minesCollection->hasMineForResource($resourceId) === false) {
+            $mine = $this->resourceMineFactory->createNew($resourceId);
+            $minesCollection->addMine($mine);
         }
 
         $resourceId = new ResourceId($event->getResourceContextId());

--- a/src/Application/Component/ResourceMines/EventListener/UpgradeMineEventListener.php
+++ b/src/Application/Component/ResourceMines/EventListener/UpgradeMineEventListener.php
@@ -17,7 +17,6 @@ final class UpgradeMineEventListener
         private readonly ResourceMinesRepositoryInterface $minesRepository,
         private readonly ResourceMinesContextInterface $resourceMinesContext,
     ) {
-
     }
 
     public function __invoke(ResourceMineConstructionHasBeenFinishedEvent $event): void
@@ -30,7 +29,8 @@ final class UpgradeMineEventListener
 
         $resourceId = new ResourceId($event->getResourceContextId());
         $newMiningSpeed = $this->resourceMinesContext->getMiningSpeed(
-            $event->getLevel(), $resourceId
+            $event->getLevel(),
+            $resourceId
         );
 
         $minesCollection->upgradeMiningSpeed(

--- a/src/Application/Component/ResourceStorage/Bridge/ResourceAvailabilityChecker.php
+++ b/src/Application/Component/ResourceStorage/Bridge/ResourceAvailabilityChecker.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\ResourceStorage\Bridge;
+
+use TheGame\Application\Component\ResourceStorage\ResourceStoragesRepositoryInterface;
+use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
+use TheGame\Application\SharedKernel\Domain\ResourceAmountInterface;
+
+final class ResourceAvailabilityChecker
+{
+    public function __construct(
+        private readonly ResourceStoragesRepositoryInterface $storagesRepository
+    ) {
+    }
+
+    /** @var ResourceAmountInterface[] $resourcesAmounts */
+    public function check(
+        PlanetIdInterface $planetId,
+        array $resourcesAmounts
+    ): bool {
+        $aggregate = $this->storagesRepository->findForPlanet($planetId);
+        foreach ($resourcesAmounts as $resourceAmount) {
+            if ($aggregate->hasEnough($resourceAmount) === false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Application/Component/ResourceStorage/Bridge/ResourceAvailabilityChecker.php
+++ b/src/Application/Component/ResourceStorage/Bridge/ResourceAvailabilityChecker.php
@@ -6,7 +6,8 @@ namespace TheGame\Application\Component\ResourceStorage\Bridge;
 
 use TheGame\Application\Component\ResourceStorage\ResourceStoragesRepositoryInterface;
 use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
-use TheGame\Application\SharedKernel\Domain\ResourceAmountInterface;
+use TheGame\Application\SharedKernel\Domain\ResourceRequirementsInterface;
+use TheGame\Application\SharedKernel\Exception\InconsistentModelException;
 
 final class ResourceAvailabilityChecker
 {
@@ -15,18 +16,17 @@ final class ResourceAvailabilityChecker
     ) {
     }
 
-    /** @var ResourceAmountInterface[] $resourcesAmounts */
     public function check(
         PlanetIdInterface $planetId,
-        array $resourcesAmounts
+        ResourceRequirementsInterface $requirements
     ): bool {
         $aggregate = $this->storagesRepository->findForPlanet($planetId);
-        foreach ($resourcesAmounts as $resourceAmount) {
-            if ($aggregate->hasEnough($resourceAmount) === false) {
-                return false;
-            }
+        if ($aggregate === null) {
+            throw new InconsistentModelException(
+                sprintf("Planet %d has no storages collection attached", $planetId->getUuid()),
+            );
         }
 
-        return true;
+        return $aggregate->hasEnough($requirements);
     }
 }

--- a/src/Application/Component/ResourceStorage/Bridge/ResourceAvailabilityChecker.php
+++ b/src/Application/Component/ResourceStorage/Bridge/ResourceAvailabilityChecker.php
@@ -12,7 +12,7 @@ use TheGame\Application\SharedKernel\Exception\InconsistentModelException;
 final class ResourceAvailabilityChecker
 {
     public function __construct(
-        private readonly ResourceStoragesRepositoryInterface $storagesRepository
+        private readonly ResourceStoragesRepositoryInterface $storagesRepository,
     ) {
     }
 

--- a/src/Application/Component/ResourceStorage/Bridge/ResourceAvailabilityCheckerInterface.php
+++ b/src/Application/Component/ResourceStorage/Bridge/ResourceAvailabilityCheckerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\ResourceStorage\Bridge;
+
+use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
+use TheGame\Application\SharedKernel\Domain\ResourceRequirementsInterface;
+
+interface ResourceAvailabilityCheckerInterface
+{
+    public function check(
+        PlanetIdInterface $planetId,
+        ResourceRequirementsInterface $requirements,
+    ): bool;
+}

--- a/src/Application/Component/ResourceStorage/Command/UseResourceCommand.php
+++ b/src/Application/Component/ResourceStorage/Command/UseResourceCommand.php
@@ -7,7 +7,7 @@ namespace TheGame\Application\Component\ResourceStorage\Command;
 use TheGame\Application\Component\ResourceStorage\Exception\InvalidUseAmountException;
 use TheGame\Application\SharedKernel\CommandInterface;
 
-final class UseResourcesCommand implements CommandInterface
+final class UseResourceCommand implements CommandInterface
 {
     public function __construct(
         private readonly string $planetId,

--- a/src/Application/Component/ResourceStorage/CommandHandler/UseResourceCommandHandler.php
+++ b/src/Application/Component/ResourceStorage/CommandHandler/UseResourceCommandHandler.php
@@ -15,7 +15,7 @@ use TheGame\Application\SharedKernel\Domain\ResourceRequirements;
 use TheGame\Application\SharedKernel\EventBusInterface;
 use TheGame\Application\SharedKernel\Exception\InconsistentModelException;
 
-final class UseResourcesCommandHandler
+final class UseResourceCommandHandler
 {
     public function __construct(
         private readonly ResourceStoragesRepositoryInterface $storagesRepository,

--- a/src/Application/Component/ResourceStorage/CommandHandler/UseResourcesCommandHandler.php
+++ b/src/Application/Component/ResourceStorage/CommandHandler/UseResourcesCommandHandler.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace TheGame\Application\Component\ResourceStorage\CommandHandler;
 
-use TheGame\Application\Component\ResourceStorage\Command\UseResourcesCommand;
+use TheGame\Application\Component\ResourceStorage\Command\UseResourceCommand;
 use TheGame\Application\Component\ResourceStorage\Domain\Event\StorageAmountHasChangedEvent;
-use TheGame\Application\Component\ResourceStorage\Domain\Exception\CannotUseUnsupportedResourceException;
 use TheGame\Application\Component\ResourceStorage\Domain\Exception\InsufficientResourcesException;
 use TheGame\Application\Component\ResourceStorage\ResourceStoragesRepositoryInterface;
 use TheGame\Application\SharedKernel\Domain\PlanetId;
 use TheGame\Application\SharedKernel\Domain\ResourceAmount;
 use TheGame\Application\SharedKernel\Domain\ResourceId;
+use TheGame\Application\SharedKernel\Domain\ResourceRequirements;
 use TheGame\Application\SharedKernel\EventBusInterface;
 use TheGame\Application\SharedKernel\Exception\InconsistentModelException;
 
@@ -23,7 +23,7 @@ final class UseResourcesCommandHandler
     ) {
     }
 
-    public function __invoke(UseResourcesCommand $command): void
+    public function __invoke(UseResourceCommand $command): void
     {
         $planetId = new PlanetId($command->getPlanetId());
         $storages = $this->storagesRepository->findForPlanet($planetId);
@@ -32,22 +32,19 @@ final class UseResourcesCommandHandler
         }
 
         $resourceId = new ResourceId($command->getResourceId());
-        $amount = new ResourceAmount($resourceId, $command->getAmount());
 
-        if ($storages->supports($amount) === false) {
-            throw new CannotUseUnsupportedResourceException(
-                $planetId,
-                $amount,
-            );
-        }
-        if ($storages->hasEnough($amount) === false) {
+        $resourceAmount = new ResourceAmount($resourceId, $command->getAmount());
+        $requirements = new ResourceRequirements();
+        $requirements->add($resourceAmount);
+
+        if ($storages->hasEnough($requirements) === false) {
             throw new InsufficientResourcesException(
                 $planetId,
-                $amount,
+                $resourceAmount,
             );
         }
 
-        $storages->use($amount);
+        $storages->use($resourceAmount);
 
         $event = new StorageAmountHasChangedEvent(
             $command->getPlanetId(),

--- a/src/Application/Component/ResourceStorage/Domain/Entity/Storage.php
+++ b/src/Application/Component/ResourceStorage/Domain/Entity/Storage.php
@@ -8,7 +8,6 @@ use TheGame\Application\Component\ResourceStorage\Domain\Exception\CannotUpgrade
 use TheGame\Application\Component\ResourceStorage\Domain\Exception\CannotUseUnsupportedResourceException;
 use TheGame\Application\Component\ResourceStorage\Domain\Exception\InsufficientResourcesException;
 use TheGame\Application\Component\ResourceStorage\Domain\StorageIdInterface;
-use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
 use TheGame\Application\SharedKernel\Domain\ResourceAmountInterface;
 use TheGame\Application\SharedKernel\Domain\ResourceIdInterface;
 

--- a/src/Application/Component/ResourceStorage/Domain/Entity/Storage.php
+++ b/src/Application/Component/ResourceStorage/Domain/Entity/Storage.php
@@ -90,7 +90,7 @@ class Storage
         throw new CannotUpgradeStorageLimitForLowerValueException(
             $this->storageId,
             $this->resourceId,
-            $this->limit,
+            $this->limit ?? 0,
             $newLimit
         );
     }

--- a/src/Application/Component/ResourceStorage/Domain/Entity/Storage.php
+++ b/src/Application/Component/ResourceStorage/Domain/Entity/Storage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TheGame\Application\Component\ResourceStorage\Domain\Entity;
 
+use TheGame\Application\Component\ResourceStorage\Domain\Exception\CannotUpgradeStorageLimitForLowerValueException;
 use TheGame\Application\Component\ResourceStorage\Domain\Exception\CannotUseUnsupportedResourceException;
 use TheGame\Application\Component\ResourceStorage\Domain\Exception\InsufficientResourcesException;
 use TheGame\Application\Component\ResourceStorage\Domain\StorageIdInterface;
@@ -43,17 +44,17 @@ class Storage
         return $this->currentAmount >= $amount->getAmount();
     }
 
-    public function use(PlanetIdInterface $planetId, ResourceAmountInterface $amount): void
+    public function use(ResourceAmountInterface $amount): void
     {
         if ($this->supports($amount) === false) {
             throw new CannotUseUnsupportedResourceException(
-                $planetId,
+                $this->storageId,
                 $amount,
             );
         }
 
         if ($this->hasEnough($amount) === false) {
-            throw new InsufficientResourcesException($planetId, $amount);
+            throw new InsufficientResourcesException($this->storageId, $amount);
         }
 
         $this->currentAmount -= $amount->getAmount();
@@ -72,5 +73,26 @@ class Storage
     public function getCurrentAmount(): int
     {
         return $this->currentAmount;
+    }
+
+    public function isForResource(ResourceIdInterface $resourceId): bool
+    {
+        return $this->resourceId->getUuid() === $resourceId->getUuid();
+    }
+
+    public function upgradeLimit(int $newLimit): void
+    {
+        if ($newLimit > $this->limit) {
+            $this->limit = $newLimit;
+
+            return;
+        }
+
+        throw new CannotUpgradeStorageLimitForLowerValueException(
+            $this->storageId,
+            $this->resourceId,
+            $this->limit,
+            $newLimit
+        );
     }
 }

--- a/src/Application/Component/ResourceStorage/Domain/Entity/StoragesCollection.php
+++ b/src/Application/Component/ResourceStorage/Domain/Entity/StoragesCollection.php
@@ -127,4 +127,15 @@ class StoragesCollection
             $resourceId,
         );
     }
+
+    public function hasStorageForResource(ResourceIdInterface $resourceId): bool
+    {
+        foreach ($this->storages as $storage) {
+            if ($storage->isForResource($resourceId) === true) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Application/Component/ResourceStorage/Domain/Entity/StoragesCollection.php
+++ b/src/Application/Component/ResourceStorage/Domain/Entity/StoragesCollection.php
@@ -12,6 +12,7 @@ use TheGame\Application\Component\ResourceStorage\Domain\Exception\InsufficientR
 use TheGame\Application\Component\ResourceStorage\Domain\StoragesCollectionIdInterface;
 use TheGame\Application\SharedKernel\Domain\PlanetId;
 use TheGame\Application\SharedKernel\Domain\ResourceAmountInterface;
+use TheGame\Application\SharedKernel\Domain\ResourceRequirementsInterface;
 
 class StoragesCollection
 {
@@ -47,15 +48,30 @@ class StoragesCollection
         return false;
     }
 
-    public function hasEnough(ResourceAmountInterface $resourceAmount): bool
+    public function hasEnough(ResourceRequirementsInterface $requirements): bool
     {
+        $requirementsArray = $requirements->getAll();
         foreach ($this->storages as $storage) {
-            if ($storage->supports($resourceAmount) === true) {
-                return $storage->hasEnough($resourceAmount);
+            foreach ($requirementsArray as $requirement) {
+                if ($storage->supports($requirement) === false) {
+                    return false;
+                }
             }
         }
 
-        return false;
+        foreach ($requirementsArray as $requirement) {
+            foreach ($this->storages as $storage) {
+                if ($storage->supports($requirement) === false) {
+                    continue;
+                }
+
+                if ($storage->hasEnough($requirement) === false) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     public function use(ResourceAmountInterface $resourceAmount): void

--- a/src/Application/Component/ResourceStorage/Domain/Exception/CannotUpgradeStorageForUnsupportedResourceException.php
+++ b/src/Application/Component/ResourceStorage/Domain/Exception/CannotUpgradeStorageForUnsupportedResourceException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\ResourceStorage\Domain\Exception;
+
+use DomainException;
+use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
+use TheGame\Application\SharedKernel\Domain\ResourceIdInterface;
+
+final class CannotUpgradeStorageForUnsupportedResourceException extends DomainException
+{
+    public function __construct(
+        PlanetIdInterface $planetId,
+        ResourceIdInterface $resourceId,
+    ) {
+        parent::__construct(
+            sprintf(
+                'Cannot upgrade storage for unsupported resource %s on planet %s',
+                $planetId->getUuid(),
+                $resourceId->getUuid(),
+            ),
+        );
+    }
+}

--- a/src/Application/Component/ResourceStorage/Domain/Exception/CannotUpgradeStorageLimitForLowerValueException.php
+++ b/src/Application/Component/ResourceStorage/Domain/Exception/CannotUpgradeStorageLimitForLowerValueException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\ResourceStorage\Domain\Exception;
+
+use DomainException;
+use TheGame\Application\Component\ResourceStorage\Domain\StorageIdInterface;
+use TheGame\Application\SharedKernel\Domain\ResourceIdInterface;
+
+final class CannotUpgradeStorageLimitForLowerValueException extends DomainException
+{
+    public function __construct(
+        StorageIdInterface $storageId,
+        ResourceIdInterface $resourceId,
+        int $previousLimit,
+        int $newLimit,
+    ) {
+        parent::__construct(
+            sprintf(
+                'Cannot upgrade storage %s of resource %s (from %d to %d)',
+                $storageId->getUuid(),
+                $resourceId->getUuid(),
+                $previousLimit,
+                $newLimit
+            ),
+        );
+    }
+}

--- a/src/Application/Component/ResourceStorage/Domain/Exception/CannotUseUnsupportedResourceException.php
+++ b/src/Application/Component/ResourceStorage/Domain/Exception/CannotUseUnsupportedResourceException.php
@@ -5,21 +5,23 @@ declare(strict_types=1);
 namespace TheGame\Application\Component\ResourceStorage\Domain\Exception;
 
 use DomainException;
+use TheGame\Application\Component\ResourceStorage\Domain\StorageIdInterface;
 use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
 use TheGame\Application\SharedKernel\Domain\ResourceAmountInterface;
 
 final class CannotUseUnsupportedResourceException extends DomainException
 {
     public function __construct(
-        PlanetIdInterface $planetId,
+        StorageIdInterface|PlanetIdInterface $resourceHolderId,
         ResourceAmountInterface $amount,
     ) {
+        $message = 'Cannot use unsupported resource %s on planet %s';
+        if ($resourceHolderId instanceof StorageIdInterface === true) {
+            $message = 'Cannot use unsupported resource %s on storage %s';
+        }
+
         parent::__construct(
-            sprintf(
-                'Cannot use unsupported resource %s on planet %s',
-                $planetId->getUuid(),
-                $amount->getResourceId()->getUuid(),
-            ),
+            sprintf($message, $resourceHolderId->getUuid(), $amount->getResourceId()->getUuid()),
         );
     }
 }

--- a/src/Application/Component/ResourceStorage/Domain/Exception/InsufficientResourcesException.php
+++ b/src/Application/Component/ResourceStorage/Domain/Exception/InsufficientResourcesException.php
@@ -5,20 +5,20 @@ declare(strict_types=1);
 namespace TheGame\Application\Component\ResourceStorage\Domain\Exception;
 
 use DomainException;
-use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
+use TheGame\Application\Component\ResourceStorage\Domain\StorageIdInterface;
 use TheGame\Application\SharedKernel\Domain\ResourceAmountInterface;
 
 final class InsufficientResourcesException extends DomainException
 {
     public function __construct(
-        PlanetIdInterface $planetId,
+        StorageIdInterface $storageId,
         ResourceAmountInterface $amount,
     ) {
         parent::__construct(
             sprintf(
-                'Cannot use %d amount of resource %s on planet %s',
+                'Cannot use %d amount of resource %s on storage %s',
                 $amount->getAmount(),
-                $planetId->getUuid(),
+                $storageId->getUuid(),
                 $amount->getResourceId()->getUuid(),
             ),
         );

--- a/src/Application/Component/ResourceStorage/Domain/Exception/InsufficientResourcesException.php
+++ b/src/Application/Component/ResourceStorage/Domain/Exception/InsufficientResourcesException.php
@@ -6,19 +6,25 @@ namespace TheGame\Application\Component\ResourceStorage\Domain\Exception;
 
 use DomainException;
 use TheGame\Application\Component\ResourceStorage\Domain\StorageIdInterface;
+use TheGame\Application\SharedKernel\Domain\PlanetIdInterface;
 use TheGame\Application\SharedKernel\Domain\ResourceAmountInterface;
 
 final class InsufficientResourcesException extends DomainException
 {
     public function __construct(
-        StorageIdInterface $storageId,
+        PlanetIdInterface|StorageIdInterface $resourcesHolderId,
         ResourceAmountInterface $amount,
     ) {
+        $message = 'Cannot use %d amount of resource %s on planet %s';
+        if ($resourcesHolderId instanceof StorageIdInterface === true) {
+            $message = 'Cannot use %d amount of resource %s on storage %s';
+        }
+
         parent::__construct(
             sprintf(
-                'Cannot use %d amount of resource %s on storage %s',
+                $message,
                 $amount->getAmount(),
-                $storageId->getUuid(),
+                $resourcesHolderId->getUuid(),
                 $amount->getResourceId()->getUuid(),
             ),
         );

--- a/src/Application/Component/ResourceStorage/EventListener/PayForConstructedBuildingListener.php
+++ b/src/Application/Component/ResourceStorage/EventListener/PayForConstructedBuildingListener.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\ResourceStorage\EventListener;
+
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\BuildingConstructionHasBeenStartedEvent;
+use TheGame\Application\Component\ResourceStorage\Command\UseResourceCommand;
+use TheGame\Application\SharedKernel\CommandBusInterface;
+
+final class PayForConstructedBuildingListener
+{
+    public function __construct(
+        private readonly CommandBusInterface $commandBus,
+    ) {
+    }
+
+    public function __invoke(BuildingConstructionHasBeenStartedEvent $event): void
+    {
+        foreach ($event->getResourceRequirements() as $resourceId => $amount) {
+            $command = new UseResourceCommand(
+                $event->getPlanetId(),
+                $resourceId,
+                $amount,
+            );
+            $this->commandBus->dispatch($command);
+        }
+    }
+}

--- a/src/Application/Component/ResourceStorage/EventListener/RefundForCancelledBuildingConstructionListener.php
+++ b/src/Application/Component/ResourceStorage/EventListener/RefundForCancelledBuildingConstructionListener.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\ResourceStorage\EventListener;
+
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\BuildingConstructionHasBeenCancelledEvent;
+use TheGame\Application\Component\ResourceStorage\Command\DispatchResourcesCommand;
+use TheGame\Application\SharedKernel\CommandBusInterface;
+
+final class RefundForCancelledBuildingConstructionListener
+{
+    public function __construct(
+        private readonly CommandBusInterface $commandBus,
+    ) {
+    }
+
+    public function __invoke(BuildingConstructionHasBeenCancelledEvent $event): void
+    {
+        foreach ($event->getResourceRequirements() as $resourceId => $amount) {
+            $command = new DispatchResourcesCommand(
+                $event->getPlanetId(),
+                $resourceId,
+                $amount,
+            );
+            $this->commandBus->dispatch($command);
+        }
+    }
+}

--- a/src/Application/Component/ResourceStorage/EventListener/UpgradeStorageEventListener.php
+++ b/src/Application/Component/ResourceStorage/EventListener/UpgradeStorageEventListener.php
@@ -17,7 +17,6 @@ final class UpgradeStorageEventListener
         private readonly ResourceStoragesRepositoryInterface $storagesRepository,
         private readonly ResourceStoragesContextInterface $resourceStoragesContext,
     ) {
-
     }
 
     public function __invoke(ResourceStorageConstructionHasBeenFinishedEvent $event): void
@@ -30,11 +29,13 @@ final class UpgradeStorageEventListener
 
         $resourceId = new ResourceId($event->getResourceContextId());
         $newLimit = $this->resourceStoragesContext->getLimit(
-            $event->getLevel(), $resourceId
+            $event->getLevel(),
+            $resourceId
         );
 
         $storages->upgradeLimit(
-            $resourceId, $newLimit
+            $resourceId,
+            $newLimit
         );
     }
 }

--- a/src/Application/Component/ResourceStorage/EventListener/UpgradeStorageEventListener.php
+++ b/src/Application/Component/ResourceStorage/EventListener/UpgradeStorageEventListener.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\Component\ResourceStorage\EventListener;
+
+use TheGame\Application\Component\Balance\Bridge\ResourceStoragesContextInterface;
+use TheGame\Application\Component\BuildingConstruction\Domain\Event\ResourceStorageConstructionHasBeenFinishedEvent;
+use TheGame\Application\Component\ResourceStorage\ResourceStoragesRepositoryInterface;
+use TheGame\Application\SharedKernel\Domain\PlanetId;
+use TheGame\Application\SharedKernel\Domain\ResourceId;
+use TheGame\Application\SharedKernel\Exception\InconsistentModelException;
+
+final class UpgradeStorageEventListener
+{
+    public function __construct(
+        private readonly ResourceStoragesRepositoryInterface $storagesRepository,
+        private readonly ResourceStoragesContextInterface $resourceStoragesContext,
+    ) {
+
+    }
+
+    public function __invoke(ResourceStorageConstructionHasBeenFinishedEvent $event): void
+    {
+        $planetId = new PlanetId($event->getPlanetId());
+        $storages = $this->storagesRepository->findForPlanet($planetId);
+        if ($storages === null) {
+            throw new InconsistentModelException(sprintf("Planet %d has no storages collection attached", $event->getPlanetId()));
+        }
+
+        $resourceId = new ResourceId($event->getResourceContextId());
+        $newLimit = $this->resourceStoragesContext->getLimit(
+            $event->getLevel(), $resourceId
+        );
+
+        $storages->upgradeLimit(
+            $resourceId, $newLimit
+        );
+    }
+}

--- a/src/Application/SharedKernel/Domain/BuildingType.php
+++ b/src/Application/SharedKernel/Domain/BuildingType.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace TheGame\Application\Component\BuildingConstruction\Domain;
+namespace TheGame\Application\SharedKernel\Domain;
 
-use TheGame\Application\Component\BuildingConstruction\Domain\Exception\InvalidBuildingTypeException;
+use TheGame\Application\SharedKernel\Domain\Exception\InvalidBuildingTypeException;
 
 final class BuildingType
 {

--- a/src/Application/SharedKernel/Domain/BuildingType.php
+++ b/src/Application/SharedKernel/Domain/BuildingType.php
@@ -6,22 +6,19 @@ namespace TheGame\Application\SharedKernel\Domain;
 
 use TheGame\Application\SharedKernel\Domain\Exception\InvalidBuildingTypeException;
 
-final class BuildingType
-{
-    private const SUPPORTED_TYPES = [
-        'mine',
-    ];
+enum BuildingType: string {
+    case ResourceMine = 'mine';
 
-    public function __construct(
-        private readonly string $type,
-    ) {
-        if (in_array($this->type, self::SUPPORTED_TYPES) === false) {
-            throw new InvalidBuildingTypeException($this->type);
-        }
-    }
+    case ResourceStorage = 'resource-storage';
 
-    public function getValue(): string
+    public static function fromName(string $name): self
     {
-        return $this->type;
+        foreach (self::cases() as $type) {
+            if ($name === $type->name) {
+                return $type;
+            }
+        }
+
+        throw new InvalidBuildingTypeException($name);
     }
-}
+};

--- a/src/Application/SharedKernel/Domain/BuildingType.php
+++ b/src/Application/SharedKernel/Domain/BuildingType.php
@@ -6,7 +6,8 @@ namespace TheGame\Application\SharedKernel\Domain;
 
 use TheGame\Application\SharedKernel\Domain\Exception\InvalidBuildingTypeException;
 
-enum BuildingType: string {
+enum BuildingType: string
+{
     case ResourceMine = 'mine';
 
     case ResourceStorage = 'resource-storage';

--- a/src/Application/SharedKernel/Domain/Exception/InvalidBuildingTypeException.php
+++ b/src/Application/SharedKernel/Domain/Exception/InvalidBuildingTypeException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TheGame\Application\Component\BuildingConstruction\Domain\Exception;
+namespace TheGame\Application\SharedKernel\Domain\Exception;
 
 use DomainException;
 

--- a/src/Application/SharedKernel/Domain/ResourceRequirements.php
+++ b/src/Application/SharedKernel/Domain/ResourceRequirements.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\SharedKernel\Domain;
+
+final class ResourceRequirements implements ResourceRequirementsInterface
+{
+    /** @var array<string, ResourceAmountInterface> */
+    private array $resources = [];
+
+    public function add(ResourceAmountInterface $resourceAmount): void
+    {
+        $resourceId = $resourceAmount->getResourceId();
+        if ($this->hasResource($resourceId)) {
+            $this->appendResource($resourceAmount);
+
+            return;
+        }
+
+        $this->resources[$resourceId->getUuid()] = $resourceAmount;
+    }
+
+    public function getAmount(ResourceIdInterface $resourceId): int
+    {
+        if ($this->hasResource($resourceId) === false) {
+            return 0;
+        }
+
+        return $this->resources[$resourceId->getUuid()]->getAmount();
+    }
+
+    private function hasResource(ResourceIdInterface $resourceId): bool
+    {
+        return isset($this->resources[$resourceId->getUuid()]);
+    }
+
+    private function appendResource(ResourceAmountInterface $incomingResourceAmount): void
+    {
+        $resourceId = $incomingResourceAmount->getResourceId();
+        $currentResourceAmount = $this->resources[$resourceId->getUuid()];
+
+        $this->resources[$resourceId->getUuid()] = new ResourceAmount(
+            $resourceId,
+            $currentResourceAmount->getAmount() + $incomingResourceAmount->getAmount(),
+        );
+    }
+
+    /** @return array<int, ResourceAmountInterface> */
+    public function getAll(): array
+    {
+        return array_values($this->resources);
+    }
+}

--- a/src/Application/SharedKernel/Domain/ResourceRequirements.php
+++ b/src/Application/SharedKernel/Domain/ResourceRequirements.php
@@ -7,7 +7,7 @@ namespace TheGame\Application\SharedKernel\Domain;
 final class ResourceRequirements implements ResourceRequirementsInterface
 {
     /** @var array<string, ResourceAmountInterface> */
-    private array $resources = [];
+    private array $requirements = [];
 
     public function add(ResourceAmountInterface $resourceAmount): void
     {
@@ -18,7 +18,7 @@ final class ResourceRequirements implements ResourceRequirementsInterface
             return;
         }
 
-        $this->resources[$resourceId->getUuid()] = $resourceAmount;
+        $this->requirements[$resourceId->getUuid()] = $resourceAmount;
     }
 
     public function getAmount(ResourceIdInterface $resourceId): int
@@ -27,28 +27,39 @@ final class ResourceRequirements implements ResourceRequirementsInterface
             return 0;
         }
 
-        return $this->resources[$resourceId->getUuid()]->getAmount();
+        return $this->requirements[$resourceId->getUuid()]->getAmount();
     }
 
     private function hasResource(ResourceIdInterface $resourceId): bool
     {
-        return isset($this->resources[$resourceId->getUuid()]);
+        return isset($this->requirements[$resourceId->getUuid()]);
     }
 
     private function appendResource(ResourceAmountInterface $incomingResourceAmount): void
     {
         $resourceId = $incomingResourceAmount->getResourceId();
-        $currentResourceAmount = $this->resources[$resourceId->getUuid()];
+        $currentResourceAmount = $this->requirements[$resourceId->getUuid()];
 
-        $this->resources[$resourceId->getUuid()] = new ResourceAmount(
+        $this->requirements[$resourceId->getUuid()] = new ResourceAmount(
             $resourceId,
             $currentResourceAmount->getAmount() + $incomingResourceAmount->getAmount(),
         );
     }
 
+    /** @return array<string, int> */
+    public function toScalarArray(): array
+    {
+        $retVal = [];
+        foreach ($this->requirements as $resourceUuid => $resourceAmount) {
+            $retVal[$resourceUuid] = $resourceAmount->getAmount();
+        }
+
+        return $retVal;
+    }
+
     /** @return array<int, ResourceAmountInterface> */
     public function getAll(): array
     {
-        return array_values($this->resources);
+        return array_values($this->requirements);
     }
 }

--- a/src/Application/SharedKernel/Domain/ResourceRequirementsInterface.php
+++ b/src/Application/SharedKernel/Domain/ResourceRequirementsInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheGame\Application\SharedKernel\Domain;
+
+interface ResourceRequirementsInterface
+{
+    public function add(ResourceAmountInterface $resourceAmount): void;
+
+    public function getAmount(ResourceIdInterface $resourceId): int;
+
+    /** @return array<int, ResourceAmountInterface> */
+    public function getAll(): array;
+}

--- a/src/Application/SharedKernel/Domain/ResourceRequirementsInterface.php
+++ b/src/Application/SharedKernel/Domain/ResourceRequirementsInterface.php
@@ -10,6 +10,9 @@ interface ResourceRequirementsInterface
 
     public function getAmount(ResourceIdInterface $resourceId): int;
 
+    /** @return array<string, int> */
+    public function toScalarArray(): array;
+
     /** @return array<int, ResourceAmountInterface> */
     public function getAll(): array;
 }

--- a/src/Application/SharedKernel/UuidGeneratorInterface.php
+++ b/src/Application/SharedKernel/UuidGeneratorInterface.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace TheGame\Application\SharedKernel;
 
 use TheGame\Application\Component\BuildingConstruction\Domain\BuildingIdInterface;
+use TheGame\Application\Component\ResourceMines\Domain\MineIdInterface;
 use TheGame\Application\Component\ResourceStorage\Domain\StorageIdInterface;
 
 interface UuidGeneratorInterface
 {
+    public function generateNewMineId(): MineIdInterface;
+
     public function generateNewStorageId(): StorageIdInterface;
 
     public function generateNewBuildingId(): BuildingIdInterface;

--- a/src/Application/SharedKernel/UuidGeneratorInterface.php
+++ b/src/Application/SharedKernel/UuidGeneratorInterface.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace TheGame\Application\SharedKernel;
 
+use TheGame\Application\Component\BuildingConstruction\Domain\BuildingIdInterface;
 use TheGame\Application\Component\ResourceStorage\Domain\StorageIdInterface;
 
 interface UuidGeneratorInterface
 {
     public function generateNewStorageId(): StorageIdInterface;
+
+    public function generateNewBuildingId(): BuildingIdInterface;
 }

--- a/src/TheGame/Application/Component/ResourceStorage/Command/UseResourcesCommand.php
+++ b/src/TheGame/Application/Component/ResourceStorage/Command/UseResourcesCommand.php
@@ -2,6 +2,6 @@
 
 namespace TheGame\Application\Component\ResourceStorage\Command;
 
-class UseResourcesCommand
+class UseResourceCommand
 {
 }

--- a/src/TheGame/Application/Component/ResourceStorage/Command/UseResourcesCommand.php
+++ b/src/TheGame/Application/Component/ResourceStorage/Command/UseResourcesCommand.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace TheGame\Application\Component\ResourceStorage\Command;
+
+class UseResourcesCommand
+{
+}

--- a/src/TheGame/Application/Component/ResourceStorage/Command/UseResourcesCommand.php
+++ b/src/TheGame/Application/Component/ResourceStorage/Command/UseResourcesCommand.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace TheGame\Application\Component\ResourceStorage\Command;
-
-class UseResourceCommand
-{
-}


### PR DESCRIPTION
The PR introduces BuildingConstruction component, which adds functionality of creating new buildings. Currently it supports (and integrates) Mine and Storage buildings.

We also have Balance component, which provides all domain-specific values, which take a part in all processes. The Balance component is not implemented yet - it provides currently only contracts.